### PR TITLE
prevent curl from sending Content-Type on PUT to S3

### DIFF
--- a/readme-sync/v0/api/1000 - api-tutorial/2100 - api-tutorial-async-2.md
+++ b/readme-sync/v0/api/1000 - api-tutorial/2100 - api-tutorial-async-2.md
@@ -62,6 +62,7 @@ Use the one-time URL you generated in the previous step to extract data from the
 
 ```json
 curl --request PUT 'YOUR_UPLOAD_URL' \
+-H "Content-Type: " \
 --data-binary '@/PATH_TO_DOWNLOADED_PDF/auto_insurance_anyco_golden.pdf'
 ```
 


### PR DESCRIPTION
Changed the command line for curl so it doesn't add Content-Type (that breaks the S3 upload)

Also, this could solve the problem for Postman (as it takes the curl command line as input),  and so make points 5 and 6 unneeded. 