### PR TITLE
openapi documentation for the document types endpoints

### DIFF
--- a/document_type.openapi.yml
+++ b/document_type.openapi.yml
@@ -1,0 +1,3129 @@
+openapi: 3.0.3
+servers: 
+  - url: https://api.sensible.so/v0
+    description: Production server (uses live data)
+info:
+  title: Document Type
+  version: 0.0.1
+paths:
+  /document_type:
+    get:
+      operationId: list_document_types
+      summary: Retrieve all document types for the current account
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAllDocumentTypes'
+          description: List of document types for the current account
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    post:
+      operationId: create_document_type
+      summary: Create a new document type
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostDocumentType'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentType'
+          description: List of document types for the current account
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+  /document_type/{id}:
+    parameters:
+      - $ref: '#/components/parameters/DocumentTypeId'
+    get:
+      operationId: get_document_type
+      summary: Retrieve an identified document type
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentType'
+          description: Identified document type
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    put:
+      operationId: replace_document_type
+      summary: Modify an indentified document type
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutDocumentType'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentType'
+          description: Identified document type
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    delete:
+      operationId: delete_document_type
+      summary: Delete an identified document type
+      responses:
+        204:
+          description: successful deletion
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+  /document_type/{id}/configurations:
+    parameters:
+      - $ref: '#/components/parameters/DocumentTypeId'
+    get:
+      operationId: list_configurations
+      summary: list all configurations in the identified document type
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAllConfigurations'
+          description: List of document types for the current account
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    post:
+      operationId: create_configuration
+      summary: create a new configuration in the identified document type
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostConfiguration'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigurationResponse'
+          description: The created configuration
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+  /document_type/{id}/configurations/{name}:
+    parameters:
+      - $ref: '#/components/parameters/DocumentTypeId'
+      - $ref: '#/components/parameters/ArtifactName'
+    get:
+      operationId: get_configuration
+      summary: retrieve an identified configuration
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigurationResponse'
+          description: The identified configuration
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    put:
+      operationId: replace_configuration
+      summary: update an identified configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutConfiguration'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigurationResponse'
+          description: The created configuration
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    delete:
+      operationId: delete_configuration
+      summary: Delete an identified configuration
+      responses:
+        204:
+          description: successful deletion
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+  /document_types/{id}/configurations/{name}/versions:
+    parameters:
+      - $ref: '#/components/parameters/DocumentTypeId'
+      - $ref: '#/components/parameters/ArtifactName'
+    get:
+      operationId: get_configuration_versions
+      responses:
+        200:
+          description: Version information for the identified configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigurationVersionsResponse'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+  /document_types/{id}/configurations/{name}/{version}:
+    parameters:
+      - $ref: '#/components/parameters/DocumentTypeId'
+      - $ref: '#/components/parameters/ArtifactName'
+      - $ref: '#/components/parameters/VersionIdentifier'
+    get:
+      operationId: get_configuration_by_version
+      summary: retrieve an identified configuration
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigurationResponse'
+          description: The identified configuration
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    put:
+      operationId: publish_configuration_by_version
+      summary: publish the identified configuration to the supplied environment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublishConfigurationVersion'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigurationResponse'
+          description: The identified configuration
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    delete:
+      operationId: delete_configuration_by_version
+      summary: delete a draft version of a configuration, or remove the publication tag from a published configuration
+      responses:
+        204:
+          description: successful deletion
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+  /document_types/{id}/goldens:
+    parameters:
+      - $ref: '#/components/parameters/DocumentTypeId'
+    get:
+      operationId: list_goldens
+      summary: list all reference documents (goldens) in the identified document type
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAllGoldens'
+          description: List of reference documents for the current account
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    post:
+      operationId: create_golden
+      summary: create a new reference document with the supplied parameters in the identified document type
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostGolden'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GoldenResponse'
+          description: The created reference document
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+  /document_types/{id}/goldens/{name}:
+    parameters:
+      - $ref: '#/components/parameters/DocumentTypeId'
+      - $ref: '#/components/parameters/ArtifactName'
+    get:
+      operationId: get_golden
+      summary: retrieve an identified reference document
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GoldenResponse'
+          description: The identified reference document
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    put:
+      operationId: update_golden
+      summary: update details of an identified reference document
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutGolden'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GoldenResponse'
+          description: The updated reference document
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    delete:
+      operationId: delete_golden
+      summary: Delete an identified reference document
+      responses:
+        204:
+          description: successful deletion
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+  /document_types/{id}/goldens/{name}/configuration:
+    parameters:
+      - $ref: '#/components/parameters/DocumentTypeId'
+      - $ref: '#/components/parameters/ArtifactName'
+    delete:
+      operationId: delete_golden_configuration
+      summary: Remove the associated configuration from the identified reference document
+      responses:
+        204:
+          description: successful deletion
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        404:
+          $ref: '#/components/responses/404'
+        415:
+          $ref: '#/components/responses/415'
+        500:
+          $ref: '#/components/responses/500'
+    
+
+# Apply the auth globally to all operations
+components:
+  parameters:
+    DocumentTypeId:
+      name: id
+      required: true
+      in: path
+      description: unique document type identifier in v4 UUID format
+      schema:
+        $ref: '#/components/schemas/UniqueId'
+    ArtifactName:
+      name: name
+      required: true
+      in: path
+      description: unique name for an internal artifact
+      schema:
+        $ref: '#/components/schemas/Name'
+    VersionIdentifier:
+      name: version
+      required: true
+      in: path
+      description: unique identifier for a configuration version
+      schema:
+        type: string
+  schemas:
+    UniqueId:
+      type: string
+      format: uuid
+      description: unique identifier
+    Name:
+      type: string
+      pattern: ^[a-z0-9_]*$
+      minLength: 3
+      maxLength: 128
+      description: user-friendly name
+    AssociatedConfigurationName:
+      type: string
+      pattern: ^[a-z0-9_]*$
+      minLength: 3
+      maxLength: 128
+      description: user-friendly name of the configuration to associate to the reference document
+    Date:
+      type: string
+      format: date-time
+      description: ISO-formatted date-time
+    Environment:
+      type: string
+      pattern: ^[a-z0-9_]*$
+      minLength: 3
+      maxLength: 128
+      description: |
+        Destination environment for publication, as a target for later extraction.
+        "production" is a special environment used as a default when no environment is specified during extraction
+        if supplied, the configuration must be valid
+    StringifiedConfiguration:
+      type: string
+      description: |
+        JSON-stringified version of the configuration, as defined by #/components/schemas/Configuration,
+        with errors allowed for draft configurations
+    PostDocumentType:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        schema:
+          $ref: '#/components/schemas/OutputSchema'
+      required:
+        - name
+        - schema
+      additionalProperties: false
+    PutDocumentType:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        schema:
+          $ref: '#/components/schemas/OutputSchema'
+      additionalProperties: false
+    GetAllDocumentTypes:
+      type: array
+      items: 
+        type: object
+        properties:
+          name:
+            $ref: '#/components/schemas/Name'
+          id:
+            $ref: '#/components/schemas/UniqueId'
+          created: 
+            $ref: '#/components/schemas/Date'
+        required:
+          - name
+          - id
+          - created
+        additionalProperties: false
+    DocumentType:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        id:
+          $ref: '#/components/schemas/UniqueId'
+        created: 
+          $ref: '#/components/schemas/Date'
+        schema:
+          $ref: '#/components/schemas/OutputSchema'
+      required:
+        - name
+        - id
+        - created
+        - schema
+      additionalProperties: false
+    ConfigurationVersion:
+      type: object
+      properties:
+        version_id:
+          type: string
+        datetime:
+          $ref: '#/components/schemas/Date'
+        environments:
+          type: array
+          items:
+            type: string
+        draft:
+          type: boolean
+      required:
+        - version_id
+        - datetime
+        - draft
+      additionalProperties: false
+    GetAllConfigurations:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            $ref: '#/components/schemas/Name'
+          created: 
+            $ref: '#/components/schemas/Date'
+          versions:
+            type: array
+            items:
+              $ref: '#/components/schemas/ConfigurationVersion'
+        required:
+          - name
+          - created
+          - versions
+        additionalProperties: false
+    PostConfiguration:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        configuration:
+          $ref: '#/components/schemas/StringifiedConfiguration'
+        publish_as:
+          $ref: '#/components/schemas/Environment'
+      required:
+        - name
+        - configuration
+      additionalProperties: false
+    PutConfiguration:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        configuration:
+          $ref: '#/components/schemas/StringifiedConfiguration'
+        publish_as:
+          $ref: '#/components/schemas/Environment'
+        current_draft:
+          type: string
+          description: |
+            version ID of the current draft of the configuration, if the current draft exists and is being replaced.
+            if the configuration is currently in draft and this is not supplied or does not match, the operation will fail
+      additionalProperties: false
+    ConfigurationResponse:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        created: 
+          $ref: '#/components/schemas/Date'
+        configuration:
+          $ref: '#/components/schemas/StringifiedConfiguration'
+        version_id:
+          type: string
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConfigurationVersion'
+      required:
+        - name
+        - created
+        - configuration
+        - version_id
+        - versions
+      additionalProperties: false
+    PublishConfigurationVersion:
+      type: object
+      properties:
+        publish_as:
+          $ref: '#/components/schemas/Environment'
+      required:
+        - publish_as
+      additionalProperties: false
+    ConfigurationVersionsResponse:
+      type: object
+      properties:
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConfigurationVersion'
+      required:
+        - versions
+      additionalProperties: false
+    GetAllGoldens:
+      type: array
+      items:
+        $ref: '#/components/schemas/GoldenResponse'
+    GoldenResponse:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        created: 
+          $ref: '#/components/schemas/Date'
+        configuration:
+          $ref: '#/components/schemas/AssociatedConfigurationName'
+        error:
+          type: string
+          description: Any errors that occurred processing the reference document
+        upload_url:
+          type: string
+          description: if present, the URL to which a reference document can be PUT. 
+        download_url:
+          type: string
+          description: if present, the URL to GET to retrieve the reference document
+        thumbnail_url:
+          type: string
+          description: if present, the URL to GET to retrieve a thumbnail image of the first page of the reference document
+      required:
+        - name
+        - created
+      additionalProperties: false
+    PostGolden:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        configuration:
+          $ref: '#/components/schemas/AssociatedConfigurationName'
+      required:
+        - name
+      additionalProperties: false
+    PutGolden:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/Name'
+        configuration:
+          $ref: '#/components/schemas/AssociatedConfigurationName'
+      additionalProperties: false
+
+# slightly modified from generated sources to match openapi changes    
+    OutputSchema:
+      type: object
+      additionalProperties: false
+      properties:
+        fingerprint_mode:
+          enum:
+            - strict
+            - fallback_to_all
+          type: string
+        ocr_engine:
+          enum:
+            - microsoft
+            - amazon
+            - google
+          type: string
+        ocr_level:
+          enum:
+            - 0
+            - 2
+            - 4
+          type: number
+        validations:
+          items:
+            $ref: "#/components/schemas/DocumentValidation"
+          type: array
+    DocumentValidation:
+      type: object
+      additionalProperties: false
+      properties:
+        description:
+          type: string
+        condition:
+          anyOf:
+            - type: string
+            - type: number
+            - type: boolean
+            - type: array
+            - type: object
+              additionalProperties: true
+        fields:
+          type: array
+          items:
+            type: string
+        severity:
+          type: string
+          enum:
+            - warning
+            - error
+      required:
+        - description
+        - condition
+    AccountingCurrencyEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - accountingCurrency
+          type: string
+      required:
+        - id
+      type: object
+    AddressEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - address
+          type: string
+      required:
+        - id
+      type: object
+    Anchor:
+      additionalProperties: false
+      properties:
+        end:
+          $ref: '#/components/schemas/AnchorComponent'
+        includeEnd:
+          type: boolean
+        match:
+          $ref: '#/components/schemas/AnchorComponent'
+        start:
+          $ref: '#/components/schemas/AnchorComponent'
+      required:
+        - match
+      type: object
+    AnchorComponent:
+      anyOf:
+        - $ref: '#/components/schemas/AnchorMatch'
+        - $ref: '#/components/schemas/PageMatcher'
+    AnchorMatch:
+      anyOf:
+        - type: string
+        - $ref: '#/components/schemas/Matcher'
+        - items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+    BooleanEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - boolean
+          type: string
+      required:
+        - id
+      type: object
+    Box:
+      additionalProperties: false
+      properties:
+        darknessThreshold:
+          type: number
+        id:
+          enum:
+            - box
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        offsetBoxes:
+          additionalProperties: false
+          properties:
+            direction:
+              $ref: '#/components/schemas/Direction'
+            number:
+              type: number
+          required:
+            - direction
+            - number
+          type: object
+        offsetX:
+          type: number
+        offsetY:
+          type: number
+        position:
+          $ref: '#/components/schemas/Direction'
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+      type: object
+    Checkbox:
+      anyOf:
+        - additionalProperties: false
+          properties:
+            darknessThreshold:
+              type: number
+            id:
+              enum:
+                - checkbox
+              type: string
+            lineFilters:
+              items:
+                $ref: '#/components/schemas/Matcher'
+              type: array
+            offsetX:
+              type: number
+            offsetY:
+              type: number
+            position:
+              $ref: '#/components/schemas/HorizontalDirection'
+            sortLines:
+              enum:
+                - readingOrderLeftToRight
+              type: string
+            tiebreaker:
+              $ref: '#/components/schemas/Tiebreaker'
+            typeFilters:
+              items:
+                $ref: '#/components/schemas/Eduction'
+              type: array
+            whitespaceFilter:
+              enum:
+                - spaces
+                - all
+              type: string
+            wordFilters:
+              items:
+                type: string
+              type: array
+            xMajorSort:
+              type: boolean
+            xRangeFilter:
+              additionalProperties: false
+              properties:
+                offsetX:
+                  type: number
+                start:
+                  $ref: '#/components/schemas/HorizontalDirection'
+                width:
+                  type: number
+              required:
+                - start
+                - offsetX
+                - width
+              type: object
+          required:
+            - id
+            - position
+          type: object
+        - additionalProperties: false
+          properties:
+            darknessThreshold:
+              type: number
+            height:
+              type: number
+            id:
+              enum:
+                - checkbox
+              type: string
+            lineFilters:
+              items:
+                $ref: '#/components/schemas/Matcher'
+              type: array
+            offsetX:
+              type: number
+            offsetY:
+              type: number
+            position:
+              $ref: '#/components/schemas/HorizontalDirection'
+            sortLines:
+              enum:
+                - readingOrderLeftToRight
+              type: string
+            tiebreaker:
+              $ref: '#/components/schemas/Tiebreaker'
+            typeFilters:
+              items:
+                $ref: '#/components/schemas/Eduction'
+              type: array
+            whitespaceFilter:
+              enum:
+                - spaces
+                - all
+              type: string
+            width:
+              type: number
+            wordFilters:
+              items:
+                type: string
+              type: array
+            xMajorSort:
+              type: boolean
+            xRangeFilter:
+              additionalProperties: false
+              properties:
+                offsetX:
+                  type: number
+                start:
+                  $ref: '#/components/schemas/HorizontalDirection'
+                width:
+                  type: number
+              required:
+                - start
+                - offsetX
+                - width
+              type: object
+          required:
+            - height
+            - id
+            - offsetX
+            - offsetY
+            - position
+            - width
+          type: object
+    Column:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - column
+          type: string
+        includeAnchor:
+          type: boolean
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+      type: object
+    ComputedEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - computed
+          type: string
+      required:
+        - id
+      type: object
+    ComputedField:
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        method:
+          $ref: '#/components/schemas/ComputedFieldMethod'
+        type:
+          $ref: '#/components/schemas/Eduction'
+      required:
+        - id
+        - method
+      type: object
+    ComputedFieldMethod:
+      anyOf:
+        - $ref: '#/components/schemas/Concat'
+        - $ref: '#/components/schemas/Constant'
+        - $ref: '#/components/schemas/Mapper'
+        - $ref: '#/components/schemas/PickValues'
+        - $ref: '#/components/schemas/Split'
+        - $ref: '#/components/schemas/Summarizer'
+        - $ref: '#/components/schemas/SuppressOutput'
+        - $ref: '#/components/schemas/Tfidf'
+        - $ref: '#/components/schemas/Zip'
+    Concat:
+      additionalProperties: false
+      properties:
+        delimiter:
+          type: string
+        id:
+          enum:
+            - concat
+          type: string
+        source_ids:
+          items:
+            type: string
+          type: array
+      required:
+        - id
+        - source_ids
+      type: object
+    Configuration:
+      additionalProperties: false
+      properties:
+        computed_fields:
+          items:
+            $ref: '#/components/schemas/ComputedField'
+          type: array
+        fields:
+          items:
+            $ref: '#/components/schemas/Field'
+          type: array
+        fingerprint:
+          $ref: '#/components/schemas/Fingerprint'
+        ocr_level:
+          enum:
+            - 0
+            - 1
+            - 2
+            - 3
+          type: number
+        preprocessors:
+          items:
+            $ref: '#/components/schemas/Preprocessor'
+          type: array
+        sections:
+          items:
+            $ref: '#/components/schemas/Section'
+          type: array
+        verbosity:
+          enum:
+            - 0
+            - 1
+            - 3
+          type: number
+      required:
+        - fields
+      type: object
+    Constant:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - constant
+          type: string
+        value:
+          type: string
+      required:
+        - id
+        - value
+      type: object
+    CurrencyEduction:
+      additionalProperties: false
+      properties:
+        currencySymbol:
+          type: string
+        decimalSeparator:
+          type: string
+        id:
+          enum:
+            - currency
+          type: string
+        maxDecimalDigits:
+          type: number
+        maxValue:
+          type: number
+        minValue:
+          type: number
+        requireCurrencySymbol:
+          type: boolean
+        requireThousandsSeparator:
+          type: boolean
+        thousandsSeparator:
+          type: string
+      required:
+        - id
+      type: object
+    CustomEduction:
+      additionalProperties: false
+      properties:
+        flags:
+          type: string
+        id:
+          enum:
+            - custom
+          type: string
+        pattern:
+          type: string
+        type:
+          type: string
+      required:
+        - id
+      type: object
+    DateEduction:
+      additionalProperties: false
+      properties:
+        format:
+          anyOf:
+            - type: string
+            - items:
+                type: string
+              type: array
+        id:
+          enum:
+            - date
+          type: string
+      required:
+        - id
+      type: object
+    DeskewAnchor:
+      additionalProperties: false
+      properties:
+        match:
+          $ref: '#/components/schemas/AnchorMatch'
+        start:
+          $ref: '#/components/schemas/HorizontalDirection'
+        targetPosition:
+          additionalProperties: false
+          properties:
+            x:
+              type: number
+            "y":
+              type: number
+          required:
+            - x
+            - "y"
+          type: object
+      required:
+        - match
+        - targetPosition
+      type: object
+    DeskewPreprocessor:
+      additionalProperties: false
+      properties:
+        fixedPoints:
+          items:
+            $ref: '#/components/schemas/DeskewAnchor'
+          maxItems: 3
+          minItems: 3
+          type: array
+        type:
+          enum:
+            - deskew
+          type: string
+      required:
+        - type
+        - fixedPoints
+      type: object
+    Direction:
+      anyOf:
+        - $ref: '#/components/schemas/HorizontalDirection'
+        - $ref: '#/components/schemas/VerticalDirection'
+    DistanceEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - distance
+          type: string
+      required:
+        - id
+      type: object
+    DocumentRange:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - documentRange
+          type: string
+        includeAnchor:
+          type: boolean
+        includeImages:
+          type: boolean
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        stop:
+          $ref: '#/components/schemas/AnchorMatch'
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+      type: object
+    DynamicTableColumn:
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        isRequired:
+          type: boolean
+        stopTerms:
+          items:
+            type: string
+          type: array
+        terms:
+          items:
+            type: string
+          type: array
+        type:
+          $ref: '#/components/schemas/Eduction'
+      required:
+        - id
+        - terms
+      type: object
+    Eduction:
+      anyOf:
+        - $ref: '#/components/schemas/StandardizedEduction'
+        - $ref: '#/components/schemas/ValueType'
+    Field:
+      additionalProperties: false
+      properties:
+        anchor:
+          $ref: '#/components/schemas/FieldAnchor'
+        id:
+          type: string
+        match:
+          $ref: '#/components/schemas/FieldSelection'
+        method:
+          $ref: '#/components/schemas/Method'
+        type:
+          $ref: '#/components/schemas/Eduction'
+      required:
+        - id
+        - method
+        - anchor
+      type: object
+    FieldAnchor:
+      anyOf:
+        - type: string
+        - $ref: '#/components/schemas/Anchor'
+    FieldSelection:
+      enum:
+        - first
+        - last
+        - all
+      type: string
+    Fingerprint:
+      additionalProperties: false
+      properties:
+        tests:
+          anyOf:
+            - items:
+                $ref: '#/components/schemas/AnchorMatch'
+              type: array
+            - items:
+                $ref: '#/components/schemas/FingerprintMatch'
+              type: array
+      required:
+        - tests
+      type: object
+    FingerprintMatch:
+      additionalProperties: false
+      properties:
+        match:
+          anyOf:
+            - items:
+                $ref: '#/components/schemas/AnchorMatch'
+              type: array
+            - $ref: '#/components/schemas/AnchorMatch'
+        offset:
+          type: number
+        page:
+          enum:
+            - first
+            - last
+            - every
+            - any
+          type: string
+      required:
+        - page
+        - match
+      type: object
+    FixedTable:
+      additionalProperties: false
+      properties:
+        columnCount:
+          type: number
+        columns:
+          items:
+            $ref: '#/components/schemas/FixedTableColumn'
+          type: array
+        id:
+          enum:
+            - fixedTable
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        startOnRow:
+          type: number
+        stop:
+          $ref: '#/components/schemas/AnchorMatch'
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - columnCount
+        - columns
+        - id
+      type: object
+    FixedTableColumn:
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        index:
+          type: number
+        isRequired:
+          type: boolean
+        type:
+          $ref: '#/components/schemas/Eduction'
+      required:
+        - id
+        - index
+      type: object
+    HorizontalDirection:
+      enum:
+        - right
+        - left
+      type: string
+    ImagesEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - images
+          type: string
+      required:
+        - id
+      type: object
+    IndexSelection:
+      anyOf:
+        - type: number
+        - items:
+            type: number
+          maxItems: 2
+          minItems: 2
+          type: array
+        - maxItems: 0
+          minItems: 0
+          type: array
+    Intersection:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - intersection
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        offsetX:
+          type: number
+        offsetY:
+          type: number
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        verticalAnchor:
+          $ref: '#/components/schemas/FieldAnchor'
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+        - verticalAnchor
+      type: object
+    Invoice:
+      additionalProperties: false
+      properties:
+        columns:
+          items:
+            $ref: '#/components/schemas/DynamicTableColumn'
+          type: array
+        id:
+          enum:
+            - invoice
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - columns
+        - id
+      type: object
+    KeyValue:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - keyValue
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        stopTerms:
+          items:
+            type: string
+          type: array
+        terms:
+          items:
+            type: string
+          type: array
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+        - terms
+      type: object
+    Label:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - label
+          type: string
+        includeAnchor:
+          type: boolean
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        position:
+          $ref: '#/components/schemas/Direction'
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        stop:
+          anyOf:
+            - enum:
+              - first
+              type: string
+            - enum:
+              - gap
+              type: string
+            - $ref: '#/components/schemas/Matcher'
+        textAlignment:
+          anyOf:
+            - $ref: '#/components/schemas/HorizontalDirection'
+            - enum:
+              - hangingIndent
+              type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+        - position
+      type: object
+    LigaturePreprocessor:
+      additionalProperties: false
+      properties:
+        forceReplaceAll:
+          type: boolean
+        mappings:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          type: object
+        type:
+          enum:
+            - ligature
+          type: string
+      required:
+        - type
+        - mappings
+      type: object
+    Mapper:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - mapper
+          type: string
+        mappings:
+          additionalProperties:
+            type: string
+          type: object
+        source_id:
+          type: string
+      required:
+        - id
+        - source_id
+        - mappings
+      type: object
+    Matcher:
+      anyOf:
+        - additionalProperties: false
+          properties:
+            isCaseSensitive:
+              type: boolean
+            maximumHeight:
+              type: number
+            minimumHeight:
+              type: number
+            reverse:
+              type: boolean
+            text:
+              type: string
+            type:
+              enum:
+                - equals
+                - startsWith
+                - includes
+                - endsWith
+              type: string
+          required:
+            - text
+            - type
+          type: object
+        - additionalProperties: false
+          properties:
+            flags:
+              type: string
+            maximumHeight:
+              type: number
+            minimumHeight:
+              type: number
+            pattern:
+              type: string
+            reverse:
+              type: boolean
+            type:
+              enum:
+                - regex
+              type: string
+          required:
+            - pattern
+            - type
+          type: object
+        - additionalProperties: false
+          properties:
+            maximumHeight:
+              type: number
+            minimumHeight:
+              type: number
+            reverse:
+              type: boolean
+            type:
+              enum:
+                - first
+              type: string
+          required:
+            - type
+          type: object
+        - additionalProperties: false
+          properties:
+            matches:
+              items:
+                anyOf:
+                  - $ref: '#/components/schemas/SimpleMatcher'
+                  - $ref: '#/components/schemas/RegexMatcher'
+              type: array
+            reverse:
+              type: boolean
+            type:
+              enum:
+                - any
+              type: string
+          required:
+            - matches
+            - type
+          type: object
+    MergeLinesPreprocessor:
+      additionalProperties: false
+      properties:
+        adjacentThreshold:
+          type: number
+        directlyAdjacentThreshold:
+          type: number
+        minXGapThreshold:
+          type: number
+        type:
+          enum:
+            - mergeLines
+          type: string
+        yOverlapThreshold:
+          type: number
+      required:
+        - type
+        - directlyAdjacentThreshold
+        - adjacentThreshold
+      type: object
+    Method:
+      anyOf:
+        - $ref: '#/components/schemas/Box'
+        - $ref: '#/components/schemas/Checkbox'
+        - $ref: '#/components/schemas/Column'
+        - $ref: '#/components/schemas/DocumentRange'
+        - $ref: '#/components/schemas/FixedTable'
+        - $ref: '#/components/schemas/Intersection'
+        - $ref: '#/components/schemas/Invoice'
+        - $ref: '#/components/schemas/KeyValue'
+        - $ref: '#/components/schemas/Label'
+        - $ref: '#/components/schemas/NearestCheckbox'
+        - $ref: '#/components/schemas/Passthrough'
+        - $ref: '#/components/schemas/Regex'
+        - $ref: '#/components/schemas/Region'
+        - $ref: '#/components/schemas/Row'
+        - $ref: '#/components/schemas/Signature'
+        - $ref: '#/components/schemas/Table'
+        - $ref: '#/components/schemas/TextTable'
+        - $ref: '#/components/schemas/Topic'
+        - $ref: '#/components/schemas/ParagraphConfig'
+    NameEduction:
+      additionalProperties: false
+      properties:
+        capitalization:
+          enum:
+            - allCaps
+            - firstLetter
+          type: string
+        id:
+          enum:
+            - name
+          type: string
+      required:
+        - id
+      type: object
+    NearestCheckbox:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - nearestCheckbox
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        offsetX:
+          type: number
+        offsetY:
+          type: number
+        position:
+          $ref: '#/components/schemas/HorizontalDirection'
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+        - position
+      type: object
+    NumberEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - number
+          type: string
+      required:
+        - id
+      type: object
+    OcrPreprocessor:
+      additionalProperties: false
+      properties:
+        match:
+          $ref: '#/components/schemas/AnchorMatch'
+        matchAll:
+          type: boolean
+        pageOffset:
+          type: number
+        type:
+          enum:
+            - ocr
+          type: string
+      required:
+        - type
+        - match
+        - pageOffset
+      type: object
+    PageFilterPreprocessor:
+      additionalProperties: false
+      properties:
+        maxPages:
+          type: number
+        stopTerms:
+          items:
+            type: string
+          type: array
+        terms:
+          items:
+            type: string
+          type: array
+        type:
+          enum:
+            - pageFilter
+          type: string
+      required:
+        - type
+        - terms
+        - maxPages
+      type: object
+    PageMatcher:
+      additionalProperties: false
+      properties:
+        stopTerms:
+          items:
+            type: string
+          type: array
+        terms:
+          items:
+            type: string
+          type: array
+        type:
+          enum:
+            - page
+          type: string
+      required:
+        - type
+        - terms
+      type: object
+    PageRangePreprocessor:
+      additionalProperties: false
+      properties:
+        endPage:
+          type: number
+        startPage:
+          type: number
+        type:
+          enum:
+            - pageRange
+          type: string
+      required:
+        - type
+      type: object
+    ParagraphConfig:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - paragraph
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+      type: object
+    ParagraphEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - paragraph
+          type: string
+      required:
+        - id
+      type: object
+    Passthrough:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - passthrough
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+      type: object
+    PercentageEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - percentage
+          type: string
+      required:
+        - id
+      type: object
+    PeriodDelimitedCurrencyEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - periodDelimitedCurrency
+          type: string
+      required:
+        - id
+      type: object
+    PhoneNumberEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - phoneNumber
+          type: string
+      required:
+        - id
+      type: object
+    PickValues:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - pickValues
+          type: string
+        match:
+          enum:
+            - one
+            - all
+          type: string
+        source_ids:
+          items:
+            type: string
+          type: array
+        value:
+          nullable: true
+          anyOf:
+            - type: boolean
+            - type: string
+            - items:
+                type: string
+              type: array
+      required:
+        - id
+        - source_ids
+      type: object
+    Preprocessor:
+      anyOf:
+        - $ref: '#/components/schemas/DeskewPreprocessor'
+        - $ref: '#/components/schemas/LigaturePreprocessor'
+        - $ref: '#/components/schemas/MergeLinesPreprocessor'
+        - $ref: '#/components/schemas/SplitLinesPreprocessor'
+        - $ref: '#/components/schemas/OcrPreprocessor'
+        - $ref: '#/components/schemas/RemoveHeaderPreprocessor'
+        - $ref: '#/components/schemas/RemoveFooterPreprocessor'
+        - $ref: '#/components/schemas/PageFilterPreprocessor'
+        - $ref: '#/components/schemas/PageRangePreprocessor'
+    Regex:
+      additionalProperties: false
+      properties:
+        flags:
+          type: string
+        id:
+          enum:
+            - regex
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        pattern:
+          type: string
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        stop:
+          $ref: '#/components/schemas/AnchorMatch'
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+        - pattern
+      type: object
+    RegexMatcher:
+      additionalProperties: false
+      properties:
+        flags:
+          type: string
+        maximumHeight:
+          type: number
+        minimumHeight:
+          type: number
+        pattern:
+          type: string
+        type:
+          enum:
+            - regex
+          type: string
+      required:
+        - pattern
+        - type
+      type: object
+    Region:
+      additionalProperties: false
+      properties:
+        height:
+          type: number
+        id:
+          enum:
+            - region
+          type: string
+        isAbsoluteOffset:
+          type: boolean
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        offsetX:
+          type: number
+        offsetY:
+          type: number
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        start:
+          $ref: '#/components/schemas/Direction'
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        width:
+          type: number
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - height
+        - id
+        - offsetX
+        - offsetY
+        - start
+        - width
+      type: object
+    RemoveFooterPreprocessor:
+      additionalProperties: false
+      properties:
+        startsOnPage:
+          type: number
+        type:
+          enum:
+            - removeFooter
+          type: string
+      required:
+        - type
+      type: object
+    RemoveHeaderPreprocessor:
+      additionalProperties: false
+      properties:
+        startsOnPage:
+          type: number
+        type:
+          enum:
+            - removeHeader
+          type: string
+      required:
+        - type
+      type: object
+    Row:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - row
+          type: string
+        includeAnchor:
+          type: boolean
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        position:
+          $ref: '#/components/schemas/HorizontalDirection'
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+      type: object
+    Section:
+      additionalProperties: false
+      properties:
+        computed_fields:
+          items:
+            $ref: '#/components/schemas/ComputedField'
+          type: array
+        fields:
+          items:
+            $ref: '#/components/schemas/Field'
+          type: array
+        id:
+          type: string
+        range:
+          $ref: '#/components/schemas/SectionRange%3CFieldAnchor%3E'
+        sections:
+          items:
+            $ref: '#/components/schemas/Section'
+          type: array
+      required:
+        - id
+        - range
+        - fields
+      type: object
+    SectionRange<FieldAnchor>:
+      anyOf:
+        - additionalProperties: false
+          properties:
+            anchor:
+              $ref: '#/components/schemas/FieldAnchor'
+            direction:
+              enum:
+                - horizontal
+              type: string
+            offsetY:
+              type: number
+            requireStop:
+              enum:
+                - false
+              type: boolean
+            stop:
+              $ref: '#/components/schemas/AnchorMatch'
+            stopOffsetY:
+              type: number
+          required:
+            - anchor
+          type: object
+        - additionalProperties: false
+          properties:
+            anchor:
+              $ref: '#/components/schemas/FieldAnchor'
+            direction:
+              enum:
+                - horizontal
+              type: string
+            offsetY:
+              type: number
+            requireStop:
+              enum:
+                - true
+              type: boolean
+            stop:
+              $ref: '#/components/schemas/AnchorMatch'
+            stopOffsetY:
+              type: number
+          required:
+            - anchor
+            - requireStop
+            - stop
+          type: object
+        - additionalProperties: false
+          properties:
+            anchor:
+              $ref: '#/components/schemas/FieldAnchor'
+            columnSelection:
+              items:
+                $ref: '#/components/schemas/IndexSelection'
+              type: array
+            direction:
+              enum:
+                - vertical
+              type: string
+            ignoredColumns:
+              items:
+                $ref: '#/components/schemas/IndexSelection'
+              type: array
+            lineFilters:
+              items:
+                $ref: '#/components/schemas/Matcher'
+              type: array
+            lineSelection:
+              items:
+                $ref: '#/components/schemas/Matcher'
+              type: array
+            minColumnGap:
+              type: number
+            offsetY:
+              type: number
+            stop:
+              $ref: '#/components/schemas/AnchorMatch'
+            stopOffsetY:
+              type: number
+          required:
+            - anchor
+            - direction
+          type: object
+    Signature:
+      additionalProperties: false
+      properties:
+        height:
+          type: number
+        id:
+          enum:
+            - signature
+          type: string
+        isAbsoluteOffset:
+          type: boolean
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        offsetX:
+          type: number
+        offsetY:
+          type: number
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        start:
+          $ref: '#/components/schemas/Direction'
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        width:
+          type: number
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - height
+        - id
+        - offsetX
+        - offsetY
+        - start
+        - width
+      type: object
+    SimpleMatcher:
+      additionalProperties: false
+      properties:
+        isCaseSensitive:
+          type: boolean
+        maximumHeight:
+          type: number
+        minimumHeight:
+          type: number
+        text:
+          type: string
+        type:
+          enum:
+            - equals
+            - startsWith
+            - includes
+            - endsWith
+          type: string
+      required:
+        - text
+        - type
+      type: object
+    Split:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - split
+          type: string
+        index:
+          type: number
+        separator:
+          type: string
+        source_id:
+          type: string
+      required:
+        - id
+        - source_id
+        - separator
+      type: object
+    SplitLinesPreprocessor:
+      additionalProperties: false
+      properties:
+        minSpaces:
+          type: number
+        separator:
+          type: string
+        type:
+          enum:
+            - splitLines
+          type: string
+      required:
+        - type
+        - minSpaces
+      type: object
+    StandardizedEduction:
+      anyOf:
+        - $ref: '#/components/schemas/AccountingCurrencyEduction'
+        - $ref: '#/components/schemas/AddressEduction'
+        - $ref: '#/components/schemas/BooleanEduction'
+        - $ref: '#/components/schemas/CurrencyEduction'
+        - $ref: '#/components/schemas/CustomEduction'
+        - $ref: '#/components/schemas/DateEduction'
+        - $ref: '#/components/schemas/DistanceEduction'
+        - $ref: '#/components/schemas/ImagesEduction'
+        - $ref: '#/components/schemas/NameEduction'
+        - $ref: '#/components/schemas/NumberEduction'
+        - $ref: '#/components/schemas/PhoneNumberEduction'
+        - $ref: '#/components/schemas/ParagraphEduction'
+        - $ref: '#/components/schemas/PercentageEduction'
+        - $ref: '#/components/schemas/PeriodDelimitedCurrencyEduction'
+        - $ref: '#/components/schemas/StringEduction'
+        - $ref: '#/components/schemas/TableEduction'
+        - $ref: '#/components/schemas/WeightEduction'
+        - $ref: '#/components/schemas/ComputedEduction'
+    StringEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - string
+          type: string
+      required:
+        - id
+      type: object
+    Summarizer:
+      additionalProperties: false
+      properties:
+        fields:
+          items:
+            type: string
+          type: array
+        id:
+          enum:
+            - summarizer
+          type: string
+        samples:
+          items:
+            additionalProperties: false
+            properties:
+              prompt:
+                type: string
+              values:
+                items:
+                  type: string
+                type: array
+            required:
+              - prompt
+              - values
+            type: object
+          type: array
+        source_id:
+          type: string
+      required:
+        - id
+        - source_id
+        - fields
+        - samples
+      type: object
+    SuppressOutput:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - suppressOutput
+          type: string
+        source_ids:
+          items:
+            type: string
+          type: array
+      required:
+        - id
+        - source_ids
+      type: object
+    Table:
+      additionalProperties: false
+      properties:
+        columns:
+          items:
+            $ref: '#/components/schemas/DynamicTableColumn'
+          type: array
+        id:
+          enum:
+            - table
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        startOnRow:
+          type: number
+        stop:
+          $ref: '#/components/schemas/AnchorMatch'
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - columns
+        - id
+      type: object
+    TableEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - table
+          type: string
+      required:
+        - id
+      type: object
+    TextTable:
+      additionalProperties: false
+      properties:
+        columns:
+          items:
+            $ref: '#/components/schemas/TextTableColumn'
+          type: array
+        columnsRelativeToAnchor:
+          type: boolean
+        detectMultipleLinesPerRow:
+          type: boolean
+        id:
+          enum:
+            - textTable
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        offsetY:
+          type: number
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        startOnRow:
+          type: number
+        stop:
+          anyOf:
+            - $ref: '#/components/schemas/AnchorMatch'
+            - type: number
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - columns
+        - id
+      type: object
+    TextTableColumn:
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        isRequired:
+          type: boolean
+        maxX:
+          type: number
+        minX:
+          type: number
+        type:
+          $ref: '#/components/schemas/Eduction'
+      required:
+        - id
+        - maxX
+        - minX
+      type: object
+    Tfidf:
+      additionalProperties: false
+      properties:
+        corpus:
+          items:
+            $ref: '#/components/schemas/TfidfDocument'
+          type: array
+        id:
+          enum:
+            - tfidf
+          type: string
+        source_id:
+          type: string
+      required:
+        - id
+        - source_id
+        - corpus
+      type: object
+    TfidfDocument:
+      additionalProperties: false
+      properties:
+        document:
+          type: string
+        id:
+          type: string
+      required:
+        - id
+        - document
+      type: object
+    Tiebreaker:
+      enum:
+        - '>'
+        - <
+        - first
+        - second
+        - third
+        - last
+        - join
+      type: string
+    Topic:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - topic
+          type: string
+        lineFilters:
+          items:
+            $ref: '#/components/schemas/Matcher'
+          type: array
+        numLines:
+          type: number
+        sortLines:
+          enum:
+            - readingOrderLeftToRight
+          type: string
+        stopTerms:
+          items:
+            type: string
+          type: array
+        terms:
+          items:
+            type: string
+          type: array
+        tiebreaker:
+          $ref: '#/components/schemas/Tiebreaker'
+        typeFilters:
+          items:
+            $ref: '#/components/schemas/Eduction'
+          type: array
+        whitespaceFilter:
+          enum:
+            - spaces
+            - all
+          type: string
+        wordFilters:
+          items:
+            type: string
+          type: array
+        xMajorSort:
+          type: boolean
+        xRangeFilter:
+          additionalProperties: false
+          properties:
+            offsetX:
+              type: number
+            start:
+              $ref: '#/components/schemas/HorizontalDirection'
+            width:
+              type: number
+          required:
+            - start
+            - offsetX
+            - width
+          type: object
+      required:
+        - id
+        - numLines
+        - terms
+      type: object
+    ValueType:
+      enum:
+        - accountingCurrency
+        - address
+        - boolean
+        - currency
+        - custom
+        - date
+        - distance
+        - images
+        - name
+        - number
+        - phoneNumber
+        - paragraph
+        - percentage
+        - periodDelimitedCurrency
+        - string
+        - table
+        - weight
+        - computed
+      type: string
+    VerticalDirection:
+      enum:
+        - below
+        - above
+      type: string
+    WeightEduction:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - weight
+          type: string
+      required:
+        - id
+      type: object
+    Zip:
+      additionalProperties: false
+      properties:
+        id:
+          enum:
+            - zip
+          type: string
+        source_ids:
+          items:
+            type: string
+          type: array
+      required:
+        - id
+        - source_ids
+      type: object
+
+  responses:
+    400:
+      description: Bad Request
+      content:
+        text/plain:
+          schema:
+            title: Bad Request
+            type: string
+    401:
+      description: Not authorized
+      content:
+        text/plain:
+          schema:
+            title: Unauthorized
+            type: string
+    404:
+      description: Not Found
+      content:
+        text/plain:
+          schema:
+            title: Not Found
+            type: string
+    415:
+      description: Unsupported Media Type
+      content:
+        text/plain:
+          schema:
+            title: Unsupported Media Type
+            type: string
+    500:
+      description: Internal Server Error
+      content:
+        text/plain:
+          schema:
+            title: Sensible encountered an unknown error
+            type: string
+  securitySchemes:
+    bearerAuth:       # arbitrary name for the security scheme
+      type: http
+      scheme: bearer
+      description: |
+        Sensible uses API keys to authenticate requests. You should have received a key as a part of onboarding, 
+        but if you're having trouble with your current key, please reach out to support@sensible.so. 
+        Keep your API keys secure and do not share them publicly accessible areas such as GitHub, client-side code, etc.
+        Authentication to the API is performed via Bearer Authentication. Provide your API key as the bearer auth value.
+# Apply the auth globally to all operations
+security:
+  - bearerAuth: []


### PR DESCRIPTION
minimally documents the endpoints for document type manipulation. happy to provide explanations of some of the weirder parts - for instance the configuration object is defined in the schema but we don't actually use it in our endpoints, we accept strings, to allow for configurations with errors to be saved

got some errors while linting but i'm not sure what to do about them - it's complaining that we aren't allowed to have the responses we generate (says who?) but they are what they are

errors

  Message :   Arrays MUST NOT be returned as the top-level structure in a response body.
  Path    :   paths./document_type.get.responses.200.content.application/json.schema
  Line    :   17

  Message :   Arrays MUST NOT be returned as the top-level structure in a response body.
  Path    :   paths./document_type/{id}/configurations.get.responses.200.content.application/json.schema
  Line    :   127

  Message :   Arrays MUST NOT be returned as the top-level structure in a response body.
  Path    :   paths./document_types/{id}/goldens.get.responses.200.content.application/json.schema
  Line    :   332
