### PR TITLE
Fix first example on validations page

### DIFF
--- a/readme-sync/v0/best-practices/4000 - validate-extractions.md
+++ b/readme-sync/v0/best-practices/4000 - validate-extractions.md
@@ -59,9 +59,9 @@ Validation 1
 - **Description**:  If OCR'd, the source text for quoted rate value is a high-quality, unblurred image.
 - **Severity**: warning
 - **Condition**:
-```
+```json
 {"or":[
-  {"not":[
+  {"!":[
     {"exists":{"var":"quote_rate.valueConfidence"}}]},
   {"and":[
     {">=": [{"var":"quote_rate.valueConfidence"},"0.90"]},


### PR DESCRIPTION
The `not` operator does not exist, should be `!`. It's unfortunate because it's the first example you see when coming to this link from the app, and the server will reject it.