### PR TITLE
Edits for pick_fields, log, and general JsonLogic

### DIFF
--- a/readme-sync/v0/senseml-reference/6500 - sections/9000 - sections-example-copy-to-section.md
+++ b/readme-sync/v0/senseml-reference/6500 - sections/9000 - sections-example-copy-to-section.md
@@ -6,7 +6,7 @@ hidden: false
 
 The following example shows using computed fields to transform sections data. The example:
 
-- Copies a policy number and name from the parent `fields` array  to each section using the Custom Computation method. The policy number and name are listed once in the document and are relevant to each extracted claim.  To access the parent array's scope from inside each section, the method uses data-structure traversal syntax (`../`).  The example shows how to transform copied data, in this case by concatenating the copied fields. 
+- Copies a policy number and name from the parent `fields` object to each section using the Custom Computation method. The policy number and name are listed once in the document and are relevant to each extracted claim.  To access the parent object's scope from inside each section, the method uses data-structure traversal syntax (`../`).  The example shows how to transform copied data, in this case by concatenating the copied fields. 
 - Redacts a telephone number. The example uses the Custom Computation method to replace digits in the number, and the Suppress Output method to omit the complete number from the output.
 
 **Config**
@@ -85,40 +85,13 @@ The following example shows using computed fields to transform sections data. Th
             "position": "right"
           }
         },
-        /* to access the `_raw_policy_number` field from
-          inside the `claims_sections field`, use
-          ../ syntax to traverse levels of scope in the
-          JSON output. e.g., use ../_raw_policy_name since 
-          it's in the parent object, one level above the
-          "claims_sections" array
-          */
-          
-        /* as an alternative to this syntax, see the copy_to_section method */
         {
-          "id": "print_policy_no",
-          "method": {
-            "id": "customComputation",
-            "jsonLogic": {
-              /*
-          print the value for ../_raw_policy_number as a field using the
-          "log" operator to ensure you're at the right traversal level
-           */
-              "log": [
-                "testing traversal for policy number w/ output as field",
-                {
-                  "var": "../_raw_policy_number.value",
-                }
-              ]
-            },
-          }
-        },
-        {
-          /* copy the policy name and policy number from the parent `fields`
-            array into each section in the `claims_sections` array */
+          /* to access the `_raw_policy_number` and `_raw_policy_name`
+          fields from inside the `claims_sections field`, use ../ syntax
+          to traverse levels of scope in the JSON output.
+          e.g., use ../_raw_policy_name since it's in the parent object, one level above the "claims_sections" array */
             
           /* as an alternative to this syntax, see the copy_to_section method */
-            
-            
           "id": "policy_name_and_number",
           "method": {
             "id": "customComputation",
@@ -128,9 +101,9 @@ The following example shows using computed fields to transform sections data. Th
                 {
                   
                   /* print a log message and field value to Errors output
-                     instead of fields output */
+                  to verify what gets returned by the logged rule */
                   "log": [
-                    "testing traversal for policy number, no field output",
+                    "testing traversal for policy name",
                     {
                       "var": "../_raw_policy_name.value"
                     },
@@ -193,8 +166,9 @@ The following image shows the example document used with this example config:
 ```json
 {
   "_raw_policy_number": {
-    "type": "string",
-    "value": "5501234567"
+    "source": "5501234567",
+    "value": 5501234567,
+    "type": "number"
   },
   "_raw_policy_name": {
     "type": "string",
@@ -206,10 +180,6 @@ The following image shows the example document used with this example config:
         "source": "1223456789",
         "value": 1223456789,
         "type": "number"
-      },
-      "print_policy_no": {
-        "value": "5501234567",
-        "type": "string"
       },
       "policy_name_and_number": {
         "value": "National Landscaping Solutions_5501234567",
@@ -226,10 +196,6 @@ The following image shows the example document used with this example config:
         "value": 9876543211,
         "type": "number"
       },
-      "print_policy_no": {
-        "value": "5501234567",
-        "type": "string"
-      },
       "policy_name_and_number": {
         "value": "National Landscaping Solutions_5501234567",
         "type": "string"
@@ -244,10 +210,6 @@ The following image shows the example document used with this example config:
         "source": "6785439210",
         "value": 6785439210,
         "type": "number"
-      },
-      "print_policy_no": {
-        "value": "5501234567",
-        "type": "string"
       },
       "policy_name_and_number": {
         "value": "National Landscaping Solutions_5501234567",
@@ -264,10 +226,6 @@ The following image shows the example document used with this example config:
         "value": 7235439210,
         "type": "number"
       },
-      "print_policy_no": {
-        "value": "5501234567",
-        "type": "string"
-      },
       "policy_name_and_number": {
         "value": "National Landscaping Solutions_5501234567",
         "type": "string"
@@ -282,10 +240,6 @@ The following image shows the example document used with this example config:
         "source": "8235439211",
         "value": 8235439211,
         "type": "number"
-      },
-      "print_policy_no": {
-        "value": "5501234567",
-        "type": "string"
       },
       "policy_name_and_number": {
         "value": "National Landscaping Solutions_5501234567",
@@ -306,61 +260,31 @@ And the `errors` output for the log operations is as follows:
 [
   {
     "type": "log",
-    "message": "testing traversal for policy number w/ output as field",
-    "result": "5501234567",
-    "field_id": "claims_sections.undefined"
-  },
-  {
-    "type": "log",
-    "message": "testing traversal for policy number, no field output",
+    "message": "testing traversal for policy name",
     "result": "National Landscaping Solutions",
     "field_id": "claims_sections.undefined"
   },
   {
     "type": "log",
-    "message": "testing traversal for policy number w/ output as field",
-    "result": "5501234567",
-    "field_id": "claims_sections.undefined"
-  },
-  {
-    "type": "log",
-    "message": "testing traversal for policy number, no field output",
+    "message": "testing traversal for policy name",
     "result": "National Landscaping Solutions",
     "field_id": "claims_sections.undefined"
   },
   {
     "type": "log",
-    "message": "testing traversal for policy number w/ output as field",
-    "result": "5501234567",
-    "field_id": "claims_sections.undefined"
-  },
-  {
-    "type": "log",
-    "message": "testing traversal for policy number, no field output",
+    "message": "testing traversal for policy name",
     "result": "National Landscaping Solutions",
     "field_id": "claims_sections.undefined"
   },
   {
     "type": "log",
-    "message": "testing traversal for policy number w/ output as field",
-    "result": "5501234567",
-    "field_id": "claims_sections.undefined"
-  },
-  {
-    "type": "log",
-    "message": "testing traversal for policy number, no field output",
+    "message": "testing traversal for policy name",
     "result": "National Landscaping Solutions",
     "field_id": "claims_sections.undefined"
   },
   {
     "type": "log",
-    "message": "testing traversal for policy number w/ output as field",
-    "result": "5501234567",
-    "field_id": "claims_sections.undefined"
-  },
-  {
-    "type": "log",
-    "message": "testing traversal for policy number, no field output",
+    "message": "testing traversal for policy name",
     "result": "National Landscaping Solutions",
     "field_id": "claims_sections.undefined"
   }

--- a/readme-sync/v0/senseml-reference/6500 - sections/9000 - sections-example-copy-to-section.md
+++ b/readme-sync/v0/senseml-reference/6500 - sections/9000 - sections-example-copy-to-section.md
@@ -87,9 +87,10 @@ The following example shows using computed fields to transform sections data. Th
         },
         /* to access the `_raw_policy_number` field from
           inside the `claims_sections field`, use
-          ../../ syntax to traverse levels of scope in the
-          JSON output. e.g., use
-          ../_raw_policy_name since it's in a parent array
+          ../ syntax to traverse levels of scope in the
+          JSON output. e.g., use ../_raw_policy_name since 
+          it's in the parent object, one level above the
+          "claims_sections" array
           */
           
         /* as an alternative to this syntax, see the copy_to_section method */
@@ -99,22 +100,13 @@ The following example shows using computed fields to transform sections data. Th
             "id": "customComputation",
             "jsonLogic": {
               /*
-          print the value for ../_raw_policy_name as a field using the
+          print the value for ../_raw_policy_number as a field using the
           "log" operator to ensure you're at the right traversal level
            */
               "log": [
                 "testing traversal for policy number w/ output as field",
                 {
-                  "var": {
-                    /* to evaluate tranversal syntax,
-                          concatenate it first,
-                          e.g., "cat" outputs 
-                          "../_raw_policy_name.value" */
-                    "cat": [
-                      "../",
-                      "_raw_policy_number.value"
-                    ]
-                  }
+                  "var": "../_raw_policy_number.value",
                 }
               ]
             },
@@ -131,7 +123,7 @@ The following example shows using computed fields to transform sections data. Th
           "method": {
             "id": "customComputation",
             "jsonLogic": {
-              /* concat the policy nam + number w/ an underscore separator */  
+              /* concat the policy name + number w/ an underscore separator */  
               "cat": [
                 {
                   
@@ -140,27 +132,13 @@ The following example shows using computed fields to transform sections data. Th
                   "log": [
                     "testing traversal for policy number, no field output",
                     {
-                      "var": {
-                        /* to evaluate tranversal syntax,
-                          concatenate it first,
-                          e.g., "cat" outputs 
-                          "../_raw_policy_name.value" */
-                        "cat": [
-                          "../",
-                          "_raw_policy_name.value"
-                        ]
-                      }
+                      "var": "../_raw_policy_name.value"
                     },
                   ]
                 },
                 "_",
                 {
-                  "var": {
-                    "cat": [
-                      "../",
-                      "_raw_policy_number.value"
-                    ]
-                  }
+                  "var": "../_raw_policy_number.value"
                 }
               ]
             }

--- a/readme-sync/v0/senseml-reference/8000 - concepts/1800 - jsonlogic.md
+++ b/readme-sync/v0/senseml-reference/8000 - concepts/1800 - jsonlogic.md
@@ -191,7 +191,7 @@ Takes as input an array, where the first argument is the log message and the sec
 }
 ```
 
-The log operation doesn't modify extracted document data. It returns its results as part of the extraction errors. The data wrapped in a log operation will be passed to whatever other operations surround it as if "log" were not there. For example `{ "*": [{ "log": ["first multiplication item", { "+": [1, 2] }], 4}] }` will return a result of 12, and will show a log in the extraction errors with the fields `"message": "first multiplication item"` and `"result": 3`.
+The log operation doesn't modify extracted document data. It returns its results as part of the extraction errors. Sensible passes the data wrapped in a log operation to whatever other operations surround it as if "log" were not there. For example `{ "*": [{ "log": ["first multiplication item", { "+": [1, 2] }], 4}] }` will return a result of 12, and will show a log in the extraction errors with the fields `"message": "first multiplication item"` and `"result": 3`.
 
 To view the results of the Log operation, see the `errors` array of the API extraction response, or in the **Errors** tab of the JSON editor's output pane. 
 

--- a/readme-sync/v0/senseml-reference/8000 - concepts/1800 - jsonlogic.md
+++ b/readme-sync/v0/senseml-reference/8000 - concepts/1800 - jsonlogic.md
@@ -191,9 +191,9 @@ Takes as input an array, where the first argument is the log message and the sec
 }
 ```
 
-The log operation doesn't modify extracted document data. It returns its results as part of the extraction errors. Sensible passes the data wrapped in a log operation to whatever other operations surround it as if "log" were not there. For example `{ "*": [{ "log": ["first multiplication item", { "+": [1, 2] }], 4}] }` will return a result of 12, and will show a log in the extraction errors with the fields `"message": "first multiplication item"` and `"result": 3`.
+The log operation doesn't modify extracted document data. It returns its results as part of the extraction errors. Sensible passes the data wrapped in a log operation to whatever other operations surround it as if "log" were not there. For example `{ "*": [{ "log": ["first multiplication item", { "+": [1, 2] }], 4}] }` returns `12` and a log in the extraction errors with the fields `"message": "first multiplication item"` and `"result": 3`.
 
-To view the results of the Log operation, see the `errors` array of the API extraction response, or in the **Errors** tab of the JSON editor's output pane. 
+To view the results of the Log operation, see the `errors` array of the API extraction response, or see the **Errors** tab of the JSON editor's output pane. 
 
 ### Examples
 

--- a/readme-sync/v0/senseml-reference/8000 - concepts/1800 - jsonlogic.md
+++ b/readme-sync/v0/senseml-reference/8000 - concepts/1800 - jsonlogic.md
@@ -24,7 +24,7 @@ Sensible supports both built-in and extended JsonLogic operators.
 ### Extended operations
 
 
-  Sensible supports extended operations available in the Json Logic Engine library.  For more information, see the [documentation](https://json-logic.github.io/json-logic-engine/docs). For example, this engine includes (but is not limited to) the following extended operations:
+  Sensible supports extended operations available in the Json Logic Engine library.  For more information, see the [documentation](https://json-logic.github.io/json-logic-engine/docs). For example, this engine includes the following extended operations:
 
   - Array operations: `"length"`, `"get"`. 
   - Miscellaneous operations: `"preserve"`, `"keys"`. 
@@ -45,7 +45,7 @@ See the following sections for more information.
 
 ## Exists
 
-Returns a boolean to indicate if the specified value exists.
+Returns a boolean to indicate if the specified value exists. Returns false if the value is null or undefined.
 
 ```json
 {
@@ -53,7 +53,9 @@ Returns a boolean to indicate if the specified value exists.
 }
 ```
 
-Most commonly used with the JsonLogic `var` operation to test that an output value isn't null. Returns true if the value being evaluated is neither null nor undefined. Can take an array (where it will check the first item only) or a single value (e.g., `{ "exists": [{ "var": "some_field" }] }` or `{ "exists": { "var": "some_field" } }`).
+Most commonly used with the JsonLogic `var` operation to test a field's output. Accepts as input:
+- a single value, e.g., `{ "exists": { "var": "some_field" } }`)
+- an array, in which case it checks the first item only, e.g., `{ "exists": [{ "var": "some_field" },...,] }`
 
 ### Examples
 

--- a/readme-sync/v0/senseml-reference/8000 - concepts/1800 - jsonlogic.md
+++ b/readme-sync/v0/senseml-reference/8000 - concepts/1800 - jsonlogic.md
@@ -67,7 +67,7 @@ Takes as input an array that can contain any depth of nested arrays, and returns
 
 ### Examples
 
-The following example uses Flatten, and also shows how JsonLogic output may be reshaped when used as part of custom computation.
+The following example shows how to flatten a nested array. It also shows how Sensible transforms the JsonLogic output into the [fields](doc:field-query-object) schema when you use Flatten inside the Custom Computation method.
 
 ````json
 {
@@ -238,7 +238,6 @@ Returns a JSON object that is an array of key/value pairs. You can nest object o
 }
 ```
 
-### Examples
 
 
 ## Replace

--- a/readme-sync/v0/senseml-reference/8000 - concepts/draft-pick-fields.md
+++ b/readme-sync/v0/senseml-reference/8000 - concepts/draft-pick-fields.md
@@ -10,37 +10,23 @@ Returns the specified fields. Takes an array of two items:
 
 ```json
 {
-    "pick_fields": [
-        { sourceContext },
-        ["field_id_1", "field_id_2", "field_id_3"]
-    ]
+  "pick_fields": [
+    sourceObject,
+    ["field_id_1", "field_id_2", "field_id_3"]
+  ]
 }
 ```
 
-returns an empty object if:
+`pick_fields` will return an empty object if:
 
 - you pass an empty array as the second argument, or if Sensible can't find the specified field IDs
--  if the source is empty, null, or undefined
+- if the source is empty, null, or undefined
 
 ### Examples
 
 #### Example 1
 
-As a simplified example, if you apply the rule:
-
-```json
-{
-  "pick_fields": [
-    // `"var": ""` returns the current context, in this case, a fields array
-    // you can use traversal syntax to access other levels of data hierarchy, e.g., "var:" "../.."  
-    { "var": "" }, 
-    // the IDs of the fields to copy into this context
-    ["field_morning", "field_afternoon"]
-  ]
-}
-```
-
-to the following extracted fields:
+As a simplified example, given the following extracted fields:
 
 ```json
 {
@@ -50,7 +36,20 @@ to the following extracted fields:
 }
 ```
 
-then the Pick Fields operator outputs:
+if you apply the rule:
+
+```json
+{
+  "pick_fields": [
+    // `"var": ""` returns the current context, in this case, the whole object described above
+    { "var": "" },
+    // the IDs of the fields to be returned by the rule
+    ["field_morning", "field_afternoon"]
+  ]
+}
+```
+
+the rule will output:
 
 ```json
 {

--- a/readme-sync/v0/senseml-reference/8000 - concepts/draft-pick-fields.md
+++ b/readme-sync/v0/senseml-reference/8000 - concepts/draft-pick-fields.md
@@ -17,10 +17,10 @@ Returns the specified fields. Takes an array of two items:
 }
 ```
 
-`pick_fields` will return an empty object if:
+The Pick Fields operator returns an empty object if:
 
 - you pass an empty array as the second argument, or if Sensible can't find the specified field IDs
-- if the source is empty, null, or undefined
+- the source is empty, null, or undefined
 
 ### Examples
 
@@ -41,7 +41,7 @@ if you apply the rule:
 ```json
 {
   "pick_fields": [
-    // `"var": ""` returns the current context, in this case, the whole object described above
+    // `"var": ""` returns the current context, in this case, the preceding extracted fields
     { "var": "" },
     // the IDs of the fields to be returned by the rule
     ["field_morning", "field_afternoon"]
@@ -49,7 +49,7 @@ if you apply the rule:
 }
 ```
 
-the rule will output:
+the rule outputs:
 
 ```json
 {


### PR DESCRIPTION
Many changes will likely be self-explanatory, but there are a few places where I'll go and add comments to the code to explain further.

- Adjusted "fields array" to "fields object" where relevant to better reflect the actual shape of the data; having a good mental model of this is important when it comes to conceptualizing how to use JsonLogic, I think referring to the object the fields appear on as an array muddies this model.
- Used traversal directly in examples, rather than concatenating
- Removed some misleading info about how `log` works:

at the "top" level, `log` behaves exactly the same as it does anywhere else. In this example:
```json
{
          "id": "print_policy_no",
          "method": {
            "id": "customComputation",
            "jsonLogic": {
              /*
          print the value for ../_raw_policy_number as a field using the
          "log" operator to ensure you're at the right traversal level
           */
              "log": [
                "testing traversal for policy number w/ output as field",
                {
                  "var": "../_raw_policy_number.value",
                }
              ]
            },
          }
        }
```
`log` actually has nothing to do with this printing to the `print_policy_no` field. It still adds the log to the errors array, and it is surfaced in the field because `print_policy_no` is being given the value of the result of `"var": "../_raw_policy_number.value". `log` works the same at all levels.