### PR TITLE
chore: add create-docs-example skill and redact_pdf script

### DIFF
--- a/.claude/skills/create-docs-example/SKILL.md
+++ b/.claude/skills/create-docs-example/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: create-docs-example
+description: Given an extractor directory path from the sensible engine repo, create or update a full-fledged documentation example — copying the golden PDF, generating a screenshot, assessing and redacting PII, and writing the example section with JSON5 comments.
+argument-hint: <path/to/extractor/dir> [doc-page-path]
+disable-model-invocation: true
+allowed-tools: Bash(pdftotext:*), Bash(pdftoppm:*), Bash(python3:*), Bash(cp:*), Read, Glob, Edit, Write
+---
+
+You are adding or updating a documentation example in the sensible-docs repo based on an extractor directory from the sensible engine repo.
+
+The arguments are: **$ARGUMENTS**
+
+Parse the arguments as follows:
+- **First token**: the extractor directory path (e.g. `extractors/sensible/removeLines`)
+- **Second token** (optional): the path to the target doc page to update (e.g. `docs/Senseml reference/preprocessors/remove-lines.md`). If provided, skip Step 2 and use this path directly.
+
+The sensible engine repo is at `../sensible` relative to this repo. So the full path to the extractor dir is `../sensible/<extractor-dir>`.
+
+## Step 1 — Read the extractor
+
+Read the config file(s) (e.g. `all.json`) and list the golden PDFs from the extractor directory:
+
+```
+../sensible/<extractor-dir>/
+├── all.json          (or other named configs)
+└── goldens/
+    └── *.pdf
+```
+
+If there are multiple golden PDFs, use the first one unless the user specifies otherwise.
+
+## Step 2 — Identify the target doc page
+
+*Skip this step if a doc page path was provided as the second argument.*
+
+Parse the extractor path to determine the doctype (the last path segment, e.g. `removeLines`).
+
+Look for an existing doc page that corresponds to this feature. Likely locations:
+- `docs/Senseml reference/preprocessors/`
+- `docs/Senseml reference/layout-based-methods/`
+- `docs/Senseml reference/llm-based-methods/`
+- `docs/Senseml reference/computed-field-methods/`
+- `docs/Senseml reference/field-query-object/`
+
+If no existing page is found, note this and ask the user where to create it before proceeding.
+
+## Step 3 — Copy the PDF and generate a screenshot
+
+Choose a short, slug-style name for the assets (e.g. `remove_lines` for `removeLines`).
+
+```bash
+cp ../sensible/<extractor-dir>/goldens/<golden>.pdf assets/pdfs/<slug>.pdf
+pdftoppm -r 150 -png -f 1 -l 1 assets/pdfs/<slug>.pdf /tmp/<slug>
+cp /tmp/<slug>-1.png assets/images/final/<slug>.png
+```
+
+Then **view the rendered PNG** using the Read tool to see what the document looks like.
+
+## Step 4 — Assess the PDF for PII
+
+Extract the full text of the PDF:
+
+```bash
+pdftotext ../sensible/<extractor-dir>/goldens/<golden>.pdf -
+```
+
+Read the output carefully and assess whether the document contains personally identifiable information (PII) that should be redacted before publishing, including:
+- Real names (student, patient, employee, customer, etc.)
+- Government or institutional IDs (SSN, student IDs, employee IDs, etc.)
+- Real addresses, phone numbers, or email addresses
+- Real institution names that shouldn't be published (e.g. real college names in a student record)
+- Any other sensitive personal details
+
+**If PII is found:** Generate appropriate fake replacements. Use clearly fictional values:
+- Names: common, generic names that are obviously placeholders (e.g. "García, Ana López" as a Spanish-language Jane Doe equivalent, "Smith, Jane" for English)
+- IDs: obviously fake numbers (e.g. `A12345678`, `123-45-6789`)
+- Institutions: "Fictional College", "Sample Company", etc.
+- Keep the overall structure realistic — don't replace so much that the document loses its illustrative value
+
+Then call the redaction script. Set `"bold": true` for text that appears bold in the PDF:
+
+```bash
+python3 scripts/redact_pdf.py \
+  --input  assets/pdfs/<slug>.pdf \
+  --output assets/pdfs/<slug>.pdf \
+  --replacements '[
+    {"find": "Real Name",   "replace": "Fake Name",   "bold": true},
+    {"find": "REAL-ID-123", "replace": "FAKE-ID-000", "bold": true}
+  ]'
+```
+
+After redacting, regenerate the screenshot:
+
+```bash
+pdftoppm -r 150 -png -f 1 -l 1 assets/pdfs/<slug>.pdf /tmp/<slug>_redacted
+cp /tmp/<slug>_redacted-1.png assets/images/final/<slug>.png
+```
+
+View the new screenshot to confirm the redactions look correct.
+
+**If no PII is found:** skip redaction and proceed.
+
+## Step 5 — Write the example section
+
+Update the `# Examples` section of the target doc page. Follow these conventions exactly:
+
+**One example, one config.** Don't split into sub-examples with `##` headings unless the features are truly independent. If the extractor config uses multiple preprocessors or options together, present them as a single unified example.
+
+**Intro:** One short paragraph (2–4 sentences) describing what the example shows and why. Use a bullet list if there are multiple distinct things happening in the config (e.g. two preprocessors doing different things). Reference the actual document type (e.g. "academic transcript", "insurance quote") not just "a document".
+
+**Config block:** Use ` ```json ` fenced code blocks. Add `/* inline comments */` (JSON5 style) to label each significant section or preprocessor — this repo supports JSON5. Comments should explain the *why*, not just restate the key name.
+
+**Example document section:**
+
+```markdown
+**Example document**
+
+<one sentence describing what to notice in the document — e.g. what will be removed or changed by the preprocessor>
+
+![Click to enlarge](https://raw.githubusercontent.com/sensible-hq/sensible-docs/v0/assets/images/final/<slug>.png)
+
+| Example document | [Download link](https://raw.githubusercontent.com/sensible-hq/sensible-docs/v0/assets/pdfs/<slug>.pdf) |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+```
+
+**Output block:** Use the actual extraction output. If the output value is a long string, truncate it with `...` after ~200 characters. Strip metadata fields (`classificationSummary`, `coverage`, `errors`, `fileMetadata`, etc.) — show only the `parsedDocument` contents. Use the redacted values in the output if you redacted the PDF.
+
+## Step 6 — Commit
+
+Stage only the files you changed:
+
+```bash
+git add assets/pdfs/<slug>.pdf assets/images/final/<slug>.png "<doc-page-path>"
+git commit -m "docs: add example for <feature>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push
+```
+
+Report back with what was done, whether PII was found and redacted, and the path to the updated doc page.

--- a/scripts/redact_pdf.py
+++ b/scripts/redact_pdf.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Redact and replace text in a PDF using PyMuPDF.
+
+Each replacement whites out the matched text and inserts the replacement
+at the same position, preserving the original font size.
+
+Usage:
+    python scripts/redact_pdf.py \\
+        --input  <path/to/input.pdf> \\
+        --output <path/to/output.pdf> \\
+        --replacements '[{"find": "Real Name", "replace": "Fake Name"}, ...]'
+
+Replacement object fields:
+    find        (required) Text to search for.
+    replace     (required) Replacement text.
+    bold        (optional, default false) Use bold (Helvetica-Bold) instead of
+                regular (Helvetica) for the replacement text.
+    page        (optional) Zero-indexed page number to restrict the search to.
+                Omit to search all pages.
+    fontsize    (optional) Font size for the replacement. Defaults to the size
+                of the first matched span, or 10 if not detectable.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    import fitz
+except ImportError:
+    print("Error: PyMuPDF not installed. Run: pip install pymupdf", file=sys.stderr)
+    sys.exit(1)
+
+
+def detect_fontsize(page: fitz.Page, text: str) -> float:
+    """Return the font size of the first span containing `text`, or 10."""
+    for block in page.get_text("dict")["blocks"]:
+        if block["type"] != 0:
+            continue
+        for line in block["lines"]:
+            for span in line["spans"]:
+                if text in span["text"]:
+                    return span["size"]
+    return 10.0
+
+
+def apply_replacement(doc: fitz.Document, find: str, replace: str,
+                      bold: bool, page_idx: int | None, fontsize: float | None) -> int:
+    """Apply one find/replace across the document (or a single page). Returns match count."""
+    pages = [doc[page_idx]] if page_idx is not None else list(doc)
+    count = 0
+    fontname = "hebo" if bold else "helv"  # hebo = Helvetica-Bold
+
+    for page in pages:
+        rects = page.search_for(find)
+        if not rects:
+            continue
+        size = fontsize or detect_fontsize(page, find)
+        for rect in rects:
+            page.add_redact_annot(
+                rect,
+                text=replace,
+                fontname=fontname,
+                fontsize=size,
+                fill=(1, 1, 1),
+                text_color=(0, 0, 0),
+                align=0,
+            )
+            count += 1
+        page.apply_redactions()
+
+    return count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Redact and replace text in a PDF."
+    )
+    parser.add_argument("--input",        required=True, type=Path, help="Input PDF path")
+    parser.add_argument("--output",       required=True, type=Path, help="Output PDF path")
+    parser.add_argument("--replacements", required=True,
+                        help='JSON array of replacement objects: [{"find":..., "replace":...}]')
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"Error: input file not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        replacements = json.loads(args.replacements)
+    except json.JSONDecodeError as e:
+        print(f"Error: invalid JSON in --replacements: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    doc = fitz.open(str(args.input))
+
+    for r in replacements:
+        find     = r["find"]
+        replace  = r["replace"]
+        bold     = r.get("bold", False)
+        page_idx = r.get("page")        # None = all pages
+        fontsize = r.get("fontsize")
+
+        count = apply_replacement(doc, find, replace, bold, page_idx, fontsize)
+        if count == 0:
+            print(f"  WARNING: no match found for {repr(find)}")
+        else:
+            print(f"  {repr(find)} → {repr(replace)} ({count} replacement{'s' if count > 1 else ''})")
+
+    doc.save(str(args.output))
+    doc.close()
+    print(f"Saved: {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `/create-docs-example` skill that automates building a full documentation example from an extractor directory: copies the golden PDF, generates a screenshot, assesses and redacts PII, and writes the example section (with JSON5 comments) into the target doc page
- Accepts an optional second argument for the target doc page path, to support future agent orchestration
- Adds `scripts/redact_pdf.py` — a PyMuPDF-based helper that accepts find/replace pairs as JSON so Claude can drive PII redaction

## Test plan
- [ ] Run `/create-docs-example extractors/sensible/removeLines` and verify the skill produces a correct example
- [ ] Test with explicit doc page arg: `/create-docs-example extractors/sensible/removeLines "docs/Senseml reference/preprocessors/remove-lines.md"`
- [ ] Verify `redact_pdf.py` handles bold/regular font detection correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)