### PR TITLE
refactor: extract shared utils and simplify llms.txt sync workflow

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,210 @@
+name: Sync docs and llms.txt
+
+on:
+  push:
+    branches:
+      - v0
+    paths:
+      - '**/*.md'
+      - 'llms.txt'
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Check for existing PR
+        id: existing_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING_PR=$(gh pr list --state open --search "Sync docs and llms.txt" --json number --jq 'length')
+          echo "count=$EXISTING_PR" >> "$GITHUB_OUTPUT"
+          if [ "$EXISTING_PR" -gt 0 ]; then
+            echo "::notice::Skipping - existing PR already open"
+          fi
+
+      # === PHASE 1: Generate missing descriptions in frontmatter ===
+
+      - name: Check for missing descriptions
+        if: steps.existing_pr.outputs.count == '0'
+        id: descriptions
+        run: |
+          MISSING=$(./scripts/descriptions/check_descriptions.py --json)
+          echo "missing=$MISSING" >> "$GITHUB_OUTPUT"
+          COUNT=$(echo "$MISSING" | jq 'length')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::warning::Missing descriptions: $COUNT files need descriptions"
+          fi
+
+      - name: Generate descriptions with Claude
+        if: steps.existing_pr.outputs.count == '0' && steps.descriptions.outputs.count != '0'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MISSING_FILES: ${{ steps.descriptions.outputs.missing }}
+        run: |
+          echo "=== Generating descriptions with Claude ==="
+          echo "$MISSING_FILES" | jq -c '.[]' | while read -r item; do
+            FILE_PATH=$(echo "$item" | jq -r '.path')
+            TITLE=$(echo "$item" | jq -r '.title')
+
+            echo "Processing: $FILE_PATH"
+
+            # Read file content (first 4000 chars for context)
+            CONTENT=$(head -c 4000 "$FILE_PATH")
+
+            # Call Claude API
+            RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
+              -H "Content-Type: application/json" \
+              -H "x-api-key: $ANTHROPIC_API_KEY" \
+              -H "anthropic-version: 2023-06-01" \
+              -d "$(jq -n \
+                --arg title "$TITLE" \
+                --arg content "$CONTENT" \
+                '{
+                  model: "claude-sonnet-4-20250514",
+                  max_tokens: 150,
+                  messages: [{
+                    role: "user",
+                    content: "Generate a concise 1-line description (max 160 characters) for this documentation page. The description should summarize what the page is about for SEO purposes. Do NOT include quotes around your response. Just return the plain description text.\n\nTitle: \($title)\n\nContent:\n\($content)"
+                  }]
+                }')")
+
+            DESCRIPTION=$(echo "$RESPONSE" | jq -r '.content[0].text' | tr -d '\n')
+
+            echo "  Generated: $DESCRIPTION"
+
+            # Update the file
+            ./scripts/descriptions/add_description.py "$FILE_PATH" "$DESCRIPTION"
+          done
+
+      # === PHASE 2: Sync llms.txt coverage and descriptions ===
+
+      - name: Check llms.txt coverage
+        if: steps.existing_pr.outputs.count == '0'
+        id: coverage
+        run: |
+          RESULT=$(./scripts/descriptions/check_llms_coverage.py --json)
+          MISSING=$(echo "$RESULT" | jq '.missing | length')
+          ORPHANED=$(echo "$RESULT" | jq '.orphaned | length')
+          HIDDEN=$(echo "$RESULT" | jq '.hidden_in_llms | length')
+          IGNORED=$(echo "$RESULT" | jq '.ignored_in_llms | length')
+          DUPLICATES=$(echo "$RESULT" | jq '.duplicates | length')
+
+          COVERAGE_ISSUES=$((MISSING + ORPHANED + HIDDEN + IGNORED + DUPLICATES))
+          echo "coverage_issues=$COVERAGE_ISSUES" >> "$GITHUB_OUTPUT"
+
+          if [ "$COVERAGE_ISSUES" -gt 0 ]; then
+            echo "::warning::Coverage issues: $MISSING missing, $ORPHANED orphaned, $HIDDEN hidden, $IGNORED ignored, $DUPLICATES duplicates"
+          fi
+
+      - name: Check llms.txt description sync
+        if: steps.existing_pr.outputs.count == '0'
+        id: sync
+        run: |
+          RESULT=$(./scripts/descriptions/sync_descriptions_to_llms.py --json)
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+          SYNC_ISSUES=$(echo "$RESULT" | jq '.updates | length')
+          echo "sync_issues=$SYNC_ISSUES" >> "$GITHUB_OUTPUT"
+
+          if [ "$SYNC_ISSUES" -gt 0 ]; then
+            echo "::warning::Sync issues: $SYNC_ISSUES descriptions out of sync"
+          fi
+
+      - name: Fix llms.txt issues
+        if: steps.existing_pr.outputs.count == '0' && (steps.coverage.outputs.coverage_issues != '0' || steps.sync.outputs.sync_issues != '0')
+        run: |
+          echo "=== Fixing llms.txt issues ==="
+
+          # Fix coverage issues first (add missing, remove orphaned/hidden/ignored, dedupe)
+          if [ "${{ steps.coverage.outputs.coverage_issues }}" != "0" ]; then
+            echo "Fixing coverage issues..."
+            ./scripts/descriptions/check_llms_coverage.py --fix
+          fi
+
+          # Then sync descriptions
+          if [ "${{ steps.sync.outputs.sync_issues }}" != "0" ]; then
+            echo "Syncing descriptions..."
+            ./scripts/descriptions/sync_descriptions_to_llms.py
+          fi
+
+      # === PHASE 3: Create PR if any changes ===
+
+      - name: Create Pull Request
+        if: steps.existing_pr.outputs.count == '0' && (steps.descriptions.outputs.count != '0' || steps.coverage.outputs.coverage_issues != '0' || steps.sync.outputs.sync_issues != '0')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SYNC_RESULT: ${{ steps.sync.outputs.result }}
+        run: |
+          # Check if there are changes
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create branch
+          BRANCH_NAME="auto/sync-docs-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+
+          # Stage and commit changes
+          git add -A
+          git commit -m "Sync docs and llms.txt"
+
+          # Push and create PR
+          git push origin "$BRANCH_NAME"
+
+          # Build PR body
+          DESCRIPTIONS_GENERATED="${{ steps.descriptions.outputs.count }}"
+          COVERAGE_ISSUES="${{ steps.coverage.outputs.coverage_issues }}"
+          SYNC_ISSUES="${{ steps.sync.outputs.sync_issues }}"
+          LLMS_UPDATES=$(echo "$SYNC_RESULT" | jq -r '.updates[] | "- \(.path)"' 2>/dev/null || echo "")
+
+          # Get list of changed files
+          FILES_CHANGED=$(git diff --name-only HEAD~1 | sed 's/^/- /')
+
+          BODY="This PR automatically syncs documentation and llms.txt.
+
+## Summary
+- Descriptions generated: ${DESCRIPTIONS_GENERATED:-0}
+- llms.txt coverage issues fixed: ${COVERAGE_ISSUES:-0}
+- llms.txt descriptions synced: ${SYNC_ISSUES:-0}
+
+## Files changed
+$FILES_CHANGED
+
+---
+*Generated by GitHub Actions*"
+
+          gh pr create \
+            --title "Sync docs and llms.txt" \
+            --body "$BODY" \
+            --head "$BRANCH_NAME" \
+            --base "${{ github.event.repository.default_branch }}"
+
+      - name: Fail if issues were found
+        if: steps.descriptions.outputs.count != '0' || steps.coverage.outputs.coverage_issues != '0' || steps.sync.outputs.sync_issues != '0'
+        run: |
+          echo "::error::Issues were found and a PR has been created to fix them."
+          echo "Please review and merge the PR."
+          exit 1

--- a/scripts/descriptions/add_description.py
+++ b/scripts/descriptions/add_description.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Update an existing metadata.description in a markdown file's front matter.
+
+Only updates files that already have a metadata.description key.
+Will not create the key if it doesn't exist.
+Respects ignore list in scripts/descriptions/description_ignore.txt.
+
+Usage: add_description.py <file_path> <description>
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+from utils import find_repo_root, load_ignore_list
+
+
+def update_file_with_description(file_path: Path, description: str) -> bool:
+    """Update the file's front matter with the new description."""
+    content = file_path.read_text(encoding="utf-8")
+
+    if not content.startswith("---"):
+        return False
+
+    end_match = re.search(r"\n---\s*(\n|$)", content[3:])
+    if not end_match:
+        return False
+
+    front_matter_text = content[3:end_match.start() + 3]
+    rest_of_file = content[end_match.end() + 3:]
+
+    # Parse YAML front matter
+    try:
+        front_matter = yaml.safe_load(front_matter_text) or {}
+    except yaml.YAMLError:
+        return False
+
+    # Only update if metadata.description key already exists
+    metadata = front_matter.get("metadata")
+    if not isinstance(metadata, dict) or "description" not in metadata:
+        return False
+
+    front_matter["metadata"]["description"] = description
+
+    # Dump back to YAML, preserving reasonable formatting
+    new_front_matter = yaml.dump(front_matter, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    new_content = f"---\n{new_front_matter}---\n{rest_of_file}"
+    file_path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <file_path> <description>", file=sys.stderr)
+        return 1
+
+    file_path = Path(sys.argv[1])
+    description = sys.argv[2]
+
+    if not file_path.exists():
+        print(f"Error: File not found: {file_path}", file=sys.stderr)
+        return 1
+
+    script_dir = Path(__file__).parent.resolve()
+    ignore_list = load_ignore_list(script_dir)
+
+    # Normalize path for comparison
+    try:
+        repo_root = find_repo_root(script_dir)
+        relative_path = str(file_path.resolve().relative_to(repo_root))
+    except ValueError:
+        relative_path = str(file_path)
+
+    if relative_path in ignore_list:
+        print(f"Skipped (in ignore list): {file_path}")
+        return 0
+
+    if update_file_with_description(file_path, description):
+        print(f"Updated: {file_path}")
+        return 0
+    else:
+        print(f"Error: Could not update {file_path}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/descriptions/check_descriptions.py
+++ b/scripts/descriptions/check_descriptions.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Check that every .md topic in dirs "docs" and "reference" that has a
+metadata.description key has a non-empty value.
+
+Reports files that have the metadata.description field but it's empty.
+Skips files with hidden: true in front matter.
+Skips files without a metadata.description key (intentionally omitted).
+Respects ignore list in scripts/descriptions/description_ignore.txt.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from utils import SEARCH_DIRS, find_repo_root, load_ignore_list, parse_front_matter
+
+
+def check_descriptions(repo_root: Path, ignore_list: set[str]) -> tuple[list[dict], list[str]]:
+    """
+    Find all .md files with empty metadata.description.
+    Only targets files that have the description key but with an empty/blank value.
+    Returns tuple of (list of files with issues, list of ignored file paths).
+    """
+    issues = []
+    ignored_files = []
+
+    for search_dir in SEARCH_DIRS:
+        dir_path = repo_root / search_dir
+        if not dir_path.exists():
+            continue
+
+        for md_path in dir_path.rglob("*.md"):
+            relative_path = md_path.relative_to(repo_root)
+
+            # Skip files in ignore list
+            if str(relative_path) in ignore_list:
+                ignored_files.append(str(relative_path))
+                continue
+
+            try:
+                content = md_path.read_text(encoding="utf-8")
+            except Exception as e:
+                issues.append({
+                    "path": str(relative_path),
+                    "title": "Unknown",
+                    "reason": f"Could not read file: {e}",
+                })
+                continue
+
+            front_matter, yaml_error = parse_front_matter(content)
+            if yaml_error:
+                issues.append({
+                    "path": str(relative_path),
+                    "title": "Unknown",
+                    "reason": f"Invalid YAML frontmatter: {yaml_error}",
+                })
+                continue
+
+            if front_matter is None:
+                continue
+
+            # Skip hidden files
+            if front_matter.get("hidden", False):
+                continue
+
+            # Skip files without a metadata block
+            metadata = front_matter.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+
+            # Skip files without a description key (intentionally omitted)
+            if "description" not in metadata:
+                continue
+
+            # Flag files where description key exists but value is empty or blank
+            description = metadata.get("description")
+            if description is None or (isinstance(description, str) and not description.strip()):
+                issues.append({
+                    "path": str(relative_path),
+                    "title": front_matter.get("title", "Unknown"),
+                    "reason": "Empty metadata.description",
+                })
+
+    return issues, ignored_files
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check for missing metadata descriptions in .md files")
+    parser.add_argument("--json", action="store_true", help="Output results as JSON (summary printed to stderr)")
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).parent.resolve()
+    repo_root = find_repo_root(script_dir)
+    ignore_list = load_ignore_list(script_dir)
+
+    issues, ignored_files = check_descriptions(repo_root, ignore_list)
+
+    if args.json:
+        print(f"Missing descriptions: {len(issues)} file(s) need descriptions.", file=sys.stderr)
+        print(json.dumps(issues))
+        return 0  # Always return 0 in JSON mode; workflow handles the count
+
+    print("Running ./scripts/descriptions/check_descriptions.py...")
+    print(f"Checking metadata descriptions in: {repo_root}\n")
+
+    if issues:
+        print("=" * 60)
+        print("FILES MISSING METADATA DESCRIPTION")
+        print("=" * 60)
+        for item in sorted(issues, key=lambda x: x["path"]):
+            print(f"  - {item['path']}")
+            print(f"    Title: {item['title']}")
+            print(f"    Issue: {item['reason']}")
+        print()
+
+    if ignored_files:
+        print("=" * 60)
+        print("FILES SKIPPED (in description_ignore.txt)")
+        print("=" * 60)
+        for path in sorted(ignored_files):
+            print(f"  - {path}")
+        print()
+
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  Files missing description: {len(issues)}")
+    print(f"  Files skipped (ignored):   {len(ignored_files)}")
+
+    if not issues:
+        print("\n✓ All visible .md files have metadata descriptions!")
+    else:
+        print(f"\n✗ {len(issues)} file(s) need descriptions added.")
+
+    return 0  # Always return 0; workflow uses JSON output count to decide next steps
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/descriptions/check_llms_coverage.py
+++ b/scripts/descriptions/check_llms_coverage.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""
+Check and optionally fix llms.txt coverage against actual .md files.
+
+Reports:
+- Missing: .md files that exist but aren't listed in llms.txt
+- Orphaned: Entries in llms.txt pointing to files that don't exist
+- Hidden in llms.txt: Files with hidden: true that shouldn't be listed
+- Ignored in llms.txt: Files in description_ignore.txt that shouldn't be listed
+- Duplicates: Multiple entries for the same file
+
+Use --fix to automatically:
+- Remove orphaned/hidden/ignored entries
+- Remove duplicate entries (keeping the one with longest description)
+- Add missing files to an "Uncategorized" section
+
+Skips files with hidden: true in front matter.
+Respects ignore list in scripts/descriptions/description_ignore.txt.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import quote, unquote
+
+from utils import SEARCH_DIRS, find_repo_root, load_ignore_list, parse_front_matter
+
+
+def get_llms_txt_entries(llms_path: Path) -> tuple[set[str], dict[str, list[dict]]]:
+    """Extract all .md file paths and entries from llms.txt.
+
+    Returns:
+        - set of unique paths
+        - dict mapping path -> list of entries (for duplicate detection)
+          Each entry has: line_num, title, description, full_line
+    """
+    content = llms_path.read_text(encoding="utf-8")
+    lines = content.split("\n")
+
+    # Match: [title](path.md) with optional ": description"
+    pattern = r"^\-? ?\[([^\]]+)\]\(([^)]+\.md)\)(?::\s*(.*))?$"
+
+    paths = set()
+    entries_by_path: dict[str, list[dict]] = {}
+
+    for line_num, line in enumerate(lines):
+        match = re.match(pattern, line)
+        if match:
+            title = match.group(1)
+            path = unquote(match.group(2))
+            description = (match.group(3) or "").strip()
+
+            paths.add(path)
+
+            if path not in entries_by_path:
+                entries_by_path[path] = []
+            entries_by_path[path].append({
+                "line_num": line_num,
+                "title": title,
+                "description": description,
+                "full_line": line,
+            })
+
+    return paths, entries_by_path
+
+
+def get_actual_md_files(repo_root: Path, ignore_list: set[str]) -> tuple[set[str], set[str], list[dict]]:
+    """Get all visible .md files in docs/ and reference/ directories.
+
+    Skips files that are in the ignore list or have hidden: true in frontmatter.
+    Returns tuple of (set of visible file paths, set of hidden file paths, list of yaml errors).
+    """
+    md_files = set()
+    hidden_files = set()
+    yaml_errors = []
+
+    for search_dir in SEARCH_DIRS:
+        dir_path = repo_root / search_dir
+        if not dir_path.exists():
+            continue
+
+        for md_path in dir_path.rglob("*.md"):
+            relative_path = str(md_path.relative_to(repo_root))
+
+            if relative_path in ignore_list:
+                continue
+
+            try:
+                content = md_path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+
+            front_matter, yaml_error = parse_front_matter(content)
+            if yaml_error:
+                yaml_errors.append({"path": relative_path, "error": yaml_error})
+                continue
+
+            if front_matter and front_matter.get("hidden", False):
+                hidden_files.add(relative_path)
+                continue
+
+            md_files.add(relative_path)
+
+    return md_files, hidden_files, yaml_errors
+
+
+def get_file_info(file_path: Path) -> dict | None:
+    """Get title and description from a markdown file's frontmatter."""
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+    front_matter, _ = parse_front_matter(content)
+    if not front_matter:
+        return None
+
+    title = front_matter.get("title", "")
+    metadata = front_matter.get("metadata", {})
+    description = metadata.get("description", "") if isinstance(metadata, dict) else ""
+
+    return {
+        "title": title or file_path.stem,
+        "description": description or "No description available",
+    }
+
+
+def check_coverage(repo_root: Path, ignore_list: set[str]) -> dict:
+    """
+    Check llms.txt coverage against actual files.
+    Returns dict with missing, orphaned, hidden, ignored, duplicate files, and yaml errors.
+    """
+    llms_path = repo_root / "llms.txt"
+
+    llms_paths, entries_by_path = get_llms_txt_entries(llms_path)
+    actual_files, hidden_files, yaml_errors = get_actual_md_files(repo_root, ignore_list)
+
+    # Files that exist but aren't in llms.txt
+    missing = sorted(actual_files - llms_paths)
+
+    # Check each llms.txt entry that's not in actual_files
+    orphaned = []
+    hidden_in_llms = []
+    ignored_in_llms = []
+
+    for path in sorted(llms_paths - actual_files):
+        file_path = repo_root / path
+
+        if not file_path.exists():
+            orphaned.append(path)
+        elif path in ignore_list:
+            ignored_in_llms.append(path)
+        elif path in hidden_files:
+            hidden_in_llms.append(path)
+        else:
+            orphaned.append(path)
+
+    # Find duplicates (paths with more than one entry)
+    duplicates = []
+    for path, entries in entries_by_path.items():
+        if len(entries) > 1:
+            duplicates.append({
+                "path": path,
+                "count": len(entries),
+                "entries": entries,
+            })
+    duplicates.sort(key=lambda x: x["path"])
+
+    return {
+        "missing": missing,
+        "orphaned": orphaned,
+        "hidden_in_llms": hidden_in_llms,
+        "ignored_in_llms": ignored_in_llms,
+        "duplicates": duplicates,
+        "yaml_errors": yaml_errors,
+        "covered": len(llms_paths & actual_files),
+        "total_files": len(actual_files),
+        "total_entries": sum(len(e) for e in entries_by_path.values()),
+    }
+
+
+def fix_coverage(repo_root: Path, issues: dict) -> dict:
+    """
+    Fix llms.txt by removing invalid/duplicate entries and adding missing files.
+    Returns dict with changes made.
+    """
+    llms_path = repo_root / "llms.txt"
+    content = llms_path.read_text(encoding="utf-8")
+
+    # Collect all paths to remove entirely
+    paths_to_remove = set(
+        issues["orphaned"] +
+        issues["hidden_in_llms"] +
+        issues["ignored_in_llms"]
+    )
+
+    # For duplicates, find lines to remove (keep the one with longest description)
+    duplicate_lines_to_remove = set()
+    deduplicated = []
+    for dup in issues.get("duplicates", []):
+        entries = dup["entries"]
+        # Sort by description length descending, keep the first (longest)
+        sorted_entries = sorted(entries, key=lambda e: len(e["description"]), reverse=True)
+        keep = sorted_entries[0]
+        for entry in sorted_entries[1:]:
+            duplicate_lines_to_remove.add(entry["line_num"])
+        deduplicated.append({
+            "path": dup["path"],
+            "kept_description": keep["description"],
+            "removed_count": len(entries) - 1,
+        })
+
+    # Remove invalid entries line by line
+    lines = content.split("\n")
+    new_lines = []
+    removed = []
+
+    # Match entries with or without description: "- [text](path.md): desc" or "[text](path.md)"
+    link_pattern = r"^-? ?\[[^\]]+\]\(([^)]+\.md)\)(?::.*)?$"
+
+    for line_num, line in enumerate(lines):
+        # Check if this is a duplicate line to remove
+        if line_num in duplicate_lines_to_remove:
+            continue
+
+        match = re.match(link_pattern, line)
+        if match:
+            path = unquote(match.group(1))
+            if path in paths_to_remove:
+                # Determine reason
+                if path in issues["orphaned"]:
+                    reason = "file doesn't exist"
+                elif path in issues["hidden_in_llms"]:
+                    reason = "hidden: true"
+                else:
+                    reason = "in ignore list"
+                removed.append({"path": path, "reason": reason})
+                continue
+        new_lines.append(line)
+
+    # Add missing files - place near siblings or create new section
+    added = []
+    link_pattern_for_dir = r"^-? ?\[[^\]]+\]\(([^)]+\.md)\)"
+
+    # Track which new sections we've added (to avoid duplicates)
+    new_sections_added = set()
+
+    for missing_path in issues["missing"]:
+        file_path = repo_root / missing_path
+        info = get_file_info(file_path)
+        if not info:
+            continue
+
+        encoded_path = quote(missing_path, safe="/")
+        entry = f"- [{info['title']}]({encoded_path}): {info['description']}"
+
+        # Get the parent directory of the missing file
+        parent_dir = str(Path(missing_path).parent)
+
+        # Find the last line that has an entry from the same directory
+        last_sibling_idx = None
+        for idx, line in enumerate(new_lines):
+            match = re.match(link_pattern_for_dir, line)
+            if match:
+                existing_path = unquote(match.group(1))
+                existing_parent = str(Path(existing_path).parent)
+                if existing_parent == parent_dir:
+                    last_sibling_idx = idx
+
+        if last_sibling_idx is not None:
+            # Insert after the last sibling
+            new_lines.insert(last_sibling_idx + 1, entry)
+        else:
+            # No siblings - create a new section based on parent directory
+            section_name = Path(parent_dir).name.replace("-", " ").replace("_", " ").title()
+            section_heading = f"## {section_name}"
+
+            # Only add section heading if we haven't already for this dir
+            if parent_dir not in new_sections_added:
+                new_lines.append("")
+                new_lines.append(section_heading)
+                new_lines.append("")
+                new_sections_added.add(parent_dir)
+
+            new_lines.append(entry)
+
+        added.append({
+            "path": missing_path,
+            "title": info["title"],
+            "description": info["description"],
+        })
+
+    # Write changes
+    new_content = "\n".join(new_lines)
+    llms_path.write_text(new_content, encoding="utf-8")
+
+    return {"removed": removed, "added": added, "deduplicated": deduplicated}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check llms.txt coverage against actual .md files"
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON (summary printed to stderr)"
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Automatically fix issues (remove invalid entries, add missing files)"
+    )
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).parent.resolve()
+    repo_root = find_repo_root(script_dir)
+
+    llms_path = repo_root / "llms.txt"
+    if not llms_path.exists():
+        if args.json:
+            print(json.dumps({"error": "llms.txt not found"}))
+        else:
+            print(f"Error: llms.txt not found at {llms_path}")
+        return 1
+
+    # Load ignore list
+    ignore_list = load_ignore_list(script_dir)
+
+    # Check coverage
+    result = check_coverage(repo_root, ignore_list)
+
+    total_issues = (
+        len(result["missing"]) +
+        len(result["orphaned"]) +
+        len(result["hidden_in_llms"]) +
+        len(result["ignored_in_llms"]) +
+        len(result["duplicates"]) +
+        len(result["yaml_errors"])
+    )
+
+    # Apply fixes if requested
+    fix_result = None
+    if args.fix and total_issues > 0:
+        fix_result = fix_coverage(repo_root, result)
+
+    # JSON output mode
+    if args.json:
+        print(
+            f"Coverage: {len(result['missing'])} missing, {len(result['orphaned'])} orphaned, "
+            f"{len(result['hidden_in_llms'])} hidden, {len(result['ignored_in_llms'])} ignored, "
+            f"{len(result['duplicates'])} duplicates.",
+            file=sys.stderr,
+        )
+        output = result
+        if fix_result:
+            output["fixed"] = fix_result
+        print(json.dumps(output))
+        return 0
+
+    # Human-readable output
+    action = "Fixing" if args.fix else "Checking"
+    print(f"{action} llms.txt coverage...")
+    print(f"Repository: {repo_root}\n")
+
+    if ignore_list:
+        print(f"Ignoring {len(ignore_list)} file(s) from description_ignore.txt\n")
+
+    if result["missing"]:
+        print("=" * 60)
+        print("MISSING FROM llms.txt")
+        print("=" * 60)
+        for path in result["missing"]:
+            print(f"  - {path}")
+        print()
+
+    if result["orphaned"]:
+        print("=" * 60)
+        print("ORPHANED ENTRIES (file doesn't exist)")
+        print("=" * 60)
+        for path in result["orphaned"]:
+            print(f"  - {path}")
+        print()
+
+    if result["hidden_in_llms"]:
+        print("=" * 60)
+        print("WARNING: Hidden files listed in llms.txt (remove these)")
+        print("=" * 60)
+        for path in result["hidden_in_llms"]:
+            print(f"  - {path}")
+        print()
+
+    if result["ignored_in_llms"]:
+        print("=" * 60)
+        print("WARNING: Ignored files listed in llms.txt (remove these)")
+        print("=" * 60)
+        for path in result["ignored_in_llms"]:
+            print(f"  - {path}")
+        print()
+
+    if result["duplicates"]:
+        print("=" * 60)
+        print("DUPLICATE ENTRIES (keeping longest description)")
+        print("=" * 60)
+        for dup in result["duplicates"]:
+            print(f"  - {dup['path']} ({dup['count']} entries)")
+        print()
+
+    if result["yaml_errors"]:
+        print("=" * 60)
+        print("YAML ERRORS (invalid frontmatter)")
+        print("=" * 60)
+        for err in result["yaml_errors"]:
+            print(f"  - {err['path']}")
+            print(f"    Error: {err['error']}")
+        print()
+
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  Total .md files:     {result['total_files']}")
+    print(f"  Covered in llms.txt: {result['covered']}")
+    print(f"  Missing entries:     {len(result['missing'])}")
+    print(f"  Orphaned entries:    {len(result['orphaned'])}")
+    print(f"  Hidden in llms.txt:  {len(result['hidden_in_llms'])}")
+    print(f"  Ignored in llms.txt: {len(result['ignored_in_llms'])}")
+    print(f"  Duplicate entries:   {len(result['duplicates'])}")
+    print(f"  YAML errors:         {len(result['yaml_errors'])}")
+
+    if total_issues == 0:
+        print("\n✓ llms.txt is fully in sync with .md files!")
+    elif fix_result:
+        dedup_count = len(fix_result.get('deduplicated', []))
+        print(f"\n✓ Fixed: {len(fix_result['removed'])} removed, {len(fix_result['added'])} added, {dedup_count} deduplicated.")
+    else:
+        print(f"\n✗ {total_issues} issue(s) found. Use --fix to repair.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/descriptions/description_ignore.txt
+++ b/scripts/descriptions/description_ignore.txt
@@ -1,0 +1,7 @@
+# Files to ignore when syncing/generating descriptions
+# One file path per line (relative to repo root)
+# Lines starting with # are comments
+
+
+# this empty shell topic is just an immediate URL redirect; it's in the API ref for better discoverability of SenseML
+reference/SenseML/senseml-reference-1.md

--- a/scripts/descriptions/sync_descriptions_to_llms.py
+++ b/scripts/descriptions/sync_descriptions_to_llms.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Update llms.txt descriptions from .md files' metadata.description.
+
+Uses the YAML front matter as the source of truth and updates
+the corresponding entries in llms.txt.
+Respects ignore list in scripts/descriptions/description_ignore.txt.
+"""
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import quote, unquote
+
+from utils import SEARCH_DIRS, find_repo_root, load_ignore_list, parse_front_matter
+
+
+def get_md_descriptions(repo_root: Path, ignore_list: set[str]) -> tuple[dict[str, str], set[str]]:
+    """
+    Get all metadata.description values from .md files.
+    Returns:
+        - dict mapping relative path -> description (for files with non-empty descriptions)
+        - set of relative paths for files with empty/missing descriptions
+    """
+    descriptions = {}
+    empty_descriptions = set()
+
+    for search_dir in SEARCH_DIRS:
+        dir_path = repo_root / search_dir
+        if not dir_path.exists():
+            continue
+
+        for md_path in dir_path.rglob("*.md"):
+            relative_path = str(md_path.relative_to(repo_root))
+
+            if relative_path in ignore_list:
+                continue
+
+            try:
+                content = md_path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+
+            front_matter, _ = parse_front_matter(content)
+            if front_matter is None:
+                continue
+
+            metadata = front_matter.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+
+            if "description" not in metadata:
+                continue
+
+            description = metadata.get("description")
+            if description and isinstance(description, str) and description.strip():
+                descriptions[relative_path] = description.strip()
+            else:
+                empty_descriptions.add(relative_path)
+
+    return descriptions, empty_descriptions
+
+
+def update_llms_txt(llms_path: Path, md_descriptions: dict[str, str], empty_descriptions: set[str], dry_run: bool) -> dict:
+    """
+    Update llms.txt with descriptions from .md files.
+    Returns stats about what was updated.
+    """
+    content = llms_path.read_text(encoding="utf-8")
+    original_content = content
+
+    # Match markdown links with descriptions: [text](path.md): description
+    pattern = r"(\[[^\]]+\]\()([^)]+\.md)(\):\s*)(.+?)(\n|$)"
+
+    updates = []
+    already_in_sync = 0
+    warnings = []
+
+    def replace_description(match):
+        nonlocal already_in_sync
+        prefix = match.group(1)
+        path = match.group(2)
+        mid = match.group(3)
+        current_desc = match.group(4).strip()
+        suffix = match.group(5)
+
+        decoded_path = unquote(path)
+
+        # Check if llms.txt has a description but frontmatter is empty
+        if decoded_path in empty_descriptions and current_desc:
+            warnings.append({
+                "path": decoded_path,
+                "llms_description": current_desc,
+            })
+            return match.group(0)
+
+        if decoded_path in md_descriptions:
+            new_desc = md_descriptions[decoded_path]
+            if current_desc != new_desc:
+                updates.append({
+                    "path": decoded_path,
+                    "from": current_desc,
+                    "to": new_desc,
+                })
+                return f"{prefix}{path}{mid}{new_desc}{suffix}"
+            else:
+                already_in_sync += 1
+
+        return match.group(0)
+
+    new_content = re.sub(pattern, replace_description, content)
+
+    if not dry_run and new_content != original_content:
+        llms_path.write_text(new_content, encoding="utf-8")
+
+    return {
+        "updates": updates,
+        "in_sync": already_in_sync,
+        "warnings": warnings,
+    }
+
+
+def main():
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(
+        description="Update llms.txt descriptions from .md files' metadata.description"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be changed without making changes"
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON, implies --dry-run (summary printed to stderr)"
+    )
+    args = parser.parse_args()
+
+    # JSON mode implies dry-run
+    if args.json:
+        args.dry_run = True
+
+    script_dir = Path(__file__).parent.resolve()
+    repo_root = find_repo_root(script_dir)
+
+    llms_path = repo_root / "llms.txt"
+    if not llms_path.exists():
+        print(f"Error: llms.txt not found at {llms_path}")
+        return 1
+
+    # Load ignore list
+    ignore_list = load_ignore_list(script_dir)
+
+    # Get descriptions from .md files
+    md_descriptions, empty_descriptions = get_md_descriptions(repo_root, ignore_list)
+
+    # Update llms.txt
+    result = update_llms_txt(llms_path, md_descriptions, empty_descriptions, args.dry_run)
+
+    # JSON output mode
+    if args.json:
+        print(f"Sync: {len(result['updates'])} description(s) out of sync.", file=sys.stderr)
+        import json as _json
+        print(_json.dumps({
+            "updates": result["updates"],
+            "warnings": result["warnings"],
+            "in_sync": result["in_sync"],
+        }))
+        return 0
+
+    print(f"Syncing descriptions to llms.txt in: {repo_root}")
+    if args.dry_run:
+        print("(DRY RUN - no files will be modified)\n")
+    else:
+        print()
+
+    if ignore_list:
+        print(f"Ignoring {len(ignore_list)} file(s) from description_ignore.txt\n")
+
+    print(f"Found {len(md_descriptions)} .md files with metadata.description\n")
+
+    # Report warnings (llms.txt has description but frontmatter is empty)
+    if result["warnings"]:
+        print("=" * 60)
+        print("WARNING: Empty frontmatter but llms.txt has description. reconcile.")
+        print("=" * 60)
+        for item in result["warnings"]:
+            print(f"  - {item['path']}")
+            print(f"      llms.txt: \"{item['llms_description']}\"")
+        print()
+
+    # Report updates
+    if result["updates"]:
+        print("=" * 60)
+        print("UPDATED" if not args.dry_run else "WOULD UPDATE")
+        print("=" * 60)
+        for item in result["updates"]:
+            print(f"  - {item['path']}")
+            print(f"      From: \"{item['from']}\"")
+            print(f"      To:   \"{item['to']}\"")
+
+    # Summary
+    print()
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  {'Would update' if args.dry_run else 'Updated'}: {len(result['updates'])}")
+    print(f"  Already in sync: {result['in_sync']}")
+    if result["warnings"]:
+        print(f"  Warnings: {len(result['warnings'])}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/descriptions/utils.py
+++ b/scripts/descriptions/utils.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Shared utilities for the descriptions scripts."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+SEARCH_DIRS = ["docs", "reference"]
+
+
+def find_repo_root(script_dir: Path) -> Path:
+    """Find the repo root from the script directory, falling back to cwd."""
+    repo_root = script_dir.parent.parent
+    if (repo_root / "docs").exists() or (repo_root / "llms.txt").exists():
+        return repo_root
+    return Path.cwd()
+
+
+def load_ignore_list(script_dir: Path) -> set[str]:
+    """Load list of files to ignore from description_ignore.txt."""
+    ignore_file = script_dir / "description_ignore.txt"
+    if not ignore_file.exists():
+        return set()
+
+    ignore_list = set()
+    for line in ignore_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            ignore_list.add(line)
+    return ignore_list
+
+
+def parse_front_matter(content: str) -> tuple[dict | None, str | None]:
+    """Extract YAML front matter from markdown content.
+
+    Returns (parsed_dict, None) on success.
+    Returns (None, None) if no front matter found.
+    Returns (None, error_message) on parse error.
+    """
+    if not content.startswith("---"):
+        return None, None
+
+    end_match = re.search(r"\n---\s*(\n|$)", content[3:])
+    if not end_match:
+        return None, None
+
+    front_matter_text = content[3:end_match.start() + 3]
+
+    try:
+        return yaml.safe_load(front_matter_text) or {}, None
+    except yaml.YAMLError as e:
+        return None, str(e)


### PR DESCRIPTION
## Summary
- Add `scripts/descriptions/utils.py` with shared `SEARCH_DIRS`, `find_repo_root`, `load_ignore_list`, and `parse_front_matter` — eliminates ~100 lines of identical code duplicated across 4 scripts
- Update all 4 scripts to import from utils
- Make `--json` modes print a brief human summary to stderr so each script runs **once** per workflow step instead of twice (was doing a full filesystem scan twice per step)
- Fix PR body indentation bug in `sync-docs.yml` — the YAML-indented heredoc was adding leading spaces to every line of the auto-generated PR body
- Remove redundant second file-read for hidden-file detection in `check_llms_coverage.py` (now tracked from the initial scan pass)
- Delete `check_llms_txt.py` — dead code fully superseded by `check_llms_coverage.py` and `sync_descriptions_to_llms.py`

## Test plan
- [ ] Verify all scripts import cleanly: `cd scripts/descriptions && python3 -c "import check_descriptions, add_description, sync_descriptions_to_llms, check_llms_coverage"`
- [ ] Run `python3 scripts/descriptions/check_descriptions.py --json` — confirm brief summary on stderr, JSON on stdout
- [ ] Run `python3 scripts/descriptions/check_llms_coverage.py --json` — confirm brief summary on stderr, JSON on stdout
- [ ] Run `python3 scripts/descriptions/sync_descriptions_to_llms.py --json` — confirm brief summary on stderr, JSON on stdout
- [ ] Trigger the sync-docs workflow and confirm auto-generated PR body has no leading spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)