### PR TITLE
chore: add create-concept-doc skill and concept topic template

### DIFF
--- a/.claude/preferences/editorial-preferences.md
+++ b/.claude/preferences/editorial-preferences.md
@@ -6,11 +6,10 @@ This file captures Frances's editorial judgment — corrections made to Claude's
 
 ## Examples
 
-**Use one example that demonstrates the feature, not a basic + advanced pair.**
-When a PR adds a new capability to an existing method, the example should showcase that capability directly. Don't add a "Basic example" first just to warm up — readers can follow a well-structured single example. Two examples side by side create cognitive overhead: readers wonder what's different and why both are needed.
+**Evaluate updating existing examples before authoring new ones**
+When a PR adds a new capability to an existing method, check existing examples to see if the new capacity can be incorporated to create a good combined example. if not, create a new example.
 
-**Truncate output to 2–3 representative rows, then `"..."`.**
-Never show the full output when the document has more than 3–4 rows/items. The reader needs to recognize the pattern, not verify every extracted value. Use `"..."` as a placeholder for omitted rows.
+
 
 **Use realistic, meaningful example data.**
 Pick example data that illustrates *why* the feature is useful. A computation that converts sales figures from millions to copies, or derives a boolean flag, is more instructive than `Widget/Gadget` or generic placeholder rows. The example data should help the reader grasp the use case, not just confirm the config runs.
@@ -22,11 +21,11 @@ Pick example data that illustrates *why* the feature is useful. A computation th
 **Scenario-first, not mechanism-first.**
 Lead with what the user experiences or what Sensible does, then explain how to configure it. The user's mental model starts with their problem, not the implementation.
 
-- **Preferred:** "Sensible can treat an attachment as a portfolio — a single file containing multiple documents — and extract each one separately."
+- **Preferred:** "If your email attachments include single files containing multiple documents (portfolios) Sensible can segment the file and extract each sub-document separately."
 - **Avoid:** "You can configure an attachment spec to use portfolio extraction, where Sensible treats a single attachment as a multi-document file."
 
-**Don't compare to other Sensible APIs unless the user needs to choose between them.**
-Explaining that email portfolio config differs from the direct extraction API creates confusion for readers who haven't encountered the API. Include API comparisons only when the reader is actively choosing between approaches.
+**Compare to other Sensible features if the user can choose between them.**
+Include comparisons only when the reader has an active choice between alternate approaches to the same problem, and indicate examples of when to choose one over the other, or pros and cons.
 
 ---
 
@@ -72,9 +71,3 @@ If new content is 1–3 sentences that extends an existing topic, work it into t
 **Why:** These filter criteria aren't configurable by the user via API — they're communicated to Sensible when setting up a processor. A reference table implies the user controls them directly, which is misleading.
 
 ---
-
-**What Claude did:** Added `### Environments` as a new H3 section with email address format + webhook routing behavior.
-
-**What Frances did:** Kept as-is.
-
-**Why:** This section has enough distinct content (address format, code example, two behavioral rules) to warrant its own heading.

--- a/.claude/skills/create-concept-doc/SKILL.md
+++ b/.claude/skills/create-concept-doc/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: create-concept-doc
+description: Create a new concept topic page in docs/Senseml reference/concepts/ — for explanatory "how it works" topics, not reference pages. Use this skill when you need to document a concept, behavior, or feature overview (not a new method, preprocessor, or config option). If you're documenting a new method or preprocessor introduced by a PR, use create-new-doc instead.
+argument-hint: "<concept-name> — <description of what to cover> [optional: PR #<number> for context]"
+disable-model-invocation: true
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr create:*), Bash(git checkout:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Read, Glob, Grep, Edit, Write
+---
+
+You are writing a new concept topic page for the Sensible docs.
+
+Parse **$ARGUMENTS** as follows:
+- **Concept name**: the topic to document (e.g., "anchor nuances", "LLM token limits")
+- **Description**: what the page should cover — may be free-form notes, a feature description, or a question to answer
+- **Optional PR reference**: if the user says `PR #<number>`, fetch it for context
+
+## Step 1 — Gather context
+
+Run in parallel:
+
+**Always:** Read 2 existing concept pages whose topic is most similar to the new page. Good choices:
+- Factual/reference-style concept → read `coverage.md` and `ocr.md`
+- Feature behavior concept → read `fallbacks.md` and `field-order.md`
+- Visual/structural concept → read `lines.md` and `anchor-nuances.md`
+- LLM-related concept → read `llm-features.md` and `prompt.md`
+
+**If a PR number was given:** Fetch it for context:
+```
+gh pr view <pr-number> --repo sensible-hq/sensible --json title,body,files
+gh pr diff <pr-number> --repo sensible-hq/sensible
+```
+
+## Step 2 — Load your guidance
+
+Read in parallel:
+- `.claude/style-guide/style-guide-overview.md` — frontmatter format, voice, formatting, cross-reference syntax
+- `.claude/style-guide/concept-topic-template.md` — concept page structure, optional elements, file naming
+
+## Step 3 — Write the page
+
+Use the template from Step 2 as your scaffold. Apply the structural variant that fits the topic shape:
+
+- **Process/how-it-works**: opening definition → numbered steps or ordered H2s → optional Troubleshooting H2
+- **Feature overview**: opening summary → H2 per feature area → links out to related reference pages
+- **Behavior with variants**: opening definition → "Default behavior" H2 → "Configurable behavior" H2 → Notes
+- **Concept with formula**: opening definition → formula/calculation H2 → example H2 → Notes
+
+Write the page at: `docs/Senseml reference/concepts/<slug>.md`
+
+Where `<slug>` is a kebab-case filename derived from the concept name (e.g., `llm-token-limits`, `anchor-nuances`).
+
+After writing the page, add the slug to `docs/Senseml reference/concepts/_order.yaml`. Insert it in a thematically logical position — group it near related concepts (e.g., LLM concepts near other LLM entries, layout concepts near lines/anchor entries).
+
+## Step 4 — Branch, commit, and open a PR
+
+Branch naming: `fe_<short_description>_docs` (Frances's initials, since you're acting on her behalf).
+
+```
+git checkout -b fe_<short_description>_docs
+git add docs/Senseml\ reference/concepts/<slug>.md docs/Senseml\ reference/concepts/_order.yaml
+git commit -m "docs: add <concept name> concept topic
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push -u origin fe_<short_description>_docs
+gh pr create --title "docs: add <concept name> concept topic" --body "..."
+```
+
+PR body should include:
+- What concept the page covers and why it's useful
+- Reference to any source PR if one was provided (`sensible-hq/sensible#<pr-number>`)
+- A short test plan checklist for the reviewer (check page renders, cross-links resolve, _order.yaml entry appears in nav)
+
+Return the PR URL to the user.

--- a/.claude/style-guide/concept-topic-template.md
+++ b/.claude/style-guide/concept-topic-template.md
@@ -1,0 +1,168 @@
+# Sensible SenseML Docs — Concept Topic Template
+
+This file is a guide for writing new concept pages under `docs/Senseml reference/concepts/`. Concept pages explain how something works — they are not reference pages (no Parameters section, no example download tables). Use the annotated template below and the structural variants section to choose the right shape for your topic.
+
+---
+
+## Frontmatter
+
+Same structure as all SenseML reference pages. Only `title` and `metadata.description` vary.
+
+```yaml
+---
+title: Concept name
+excerpt: ''
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: 'Short phrase describing the concept'
+  robots: index
+next:
+  description: ''
+---
+```
+
+`metadata.description` is 4–7 words, lowercase except proper nouns. Examples:
+- `'Understanding extraction coverage'`
+- `'Control field extraction order'`
+- `'Optical character recognition overview'`
+- `'Understanding text lines in PDFs'`
+
+---
+
+## Opening paragraph
+
+1–4 sentences that define the concept and state why it matters. Use imperative or declarative tone — start with a verb or a noun phrase, not "The X is...".
+
+**Good examples from existing pages:**
+- "Extraction coverage measures how fully an extraction captures your target data from the document."
+- "Use fallback fields to handle document variations in a document type. If a field fails to extract data, you can specify a backup, or fallback field to extract the same data using a different method."
+- "A *line* is a rectangular region containing text. Sensible represents a line's boundary box as a gray box."
+
+**Optionally, add an advanced-topic callout right before the opening paragraph** when the concept is for experienced users only:
+
+```markdown
+**Note:** If you're familiar with Sensible, this advanced topic is for you.
+```
+
+---
+
+## H2 section structure
+
+Concept pages use H2 headings to divide the body. There is no prescribed list of sections — choose headings that match the topic shape.
+
+**Common H2 patterns:**
+
+| Topic shape | Typical H2 sections |
+|---|---|
+| How a feature works (process/steps) | How X works, Configuration options, Troubleshooting |
+| Reference overview (links out to related features) | Feature area 1, Feature area 2 |
+| Concept with variants | Default behavior, Configurable behavior, Notes |
+| Concept with formula or calculation | Formula, Example, Notes |
+| Comparison of options | (table in intro), then one H2 per option |
+
+---
+
+## Optional elements
+
+### Limitations block
+
+Use bold "**Limitations:**" (not an H2) followed by a bullet list when there are hard constraints on the feature. Place this in the opening section, not as a footer.
+
+```markdown
+**Limitations:**
+
+* Fallbacks don't work across nested objects.
+* Fallbacks don't work within a Query Group method.
+```
+
+### Notes section
+
+Use `## Notes` (H2) for miscellaneous callouts that don't fit in the body. For very short notes lists, use bold `**Notes**` (not H2) followed by bullets.
+
+```markdown
+## Notes
+
+* Sensible excludes suppressed fields when calculating coverage.
+* The overall coverage for a portfolio document is the weighted average of all subdocument coverages.
+```
+
+### Option comparison table
+
+When the concept has multiple configuration approaches, a comparison table in the intro is effective before diving into per-option H2 sections.
+
+```markdown
+| option | configurable for | notes |
+| ------ | ---------------- | ----- |
+| [OCR Level parameter](doc:ocr-level) | document types | Use to configure whole-document OCR criteria. |
+| [OCR preprocessor](doc:ocr-preprocessor) | configs | Use to OCR specified pages or page ranges. |
+```
+
+### Code examples
+
+Use fenced ` ```json ` blocks. Inline `//` comments are acceptable — Sensible accepts relaxed JSON.
+
+Concept pages typically embed code inline rather than using the "Config / Example document / Output" scaffold from reference pages. Truncate illustrative output to 2–3 representative lines + `"..."` if needed.
+
+### Images
+
+```markdown
+![Click to enlarge](https://raw.githubusercontent.com/sensible-hq/sensible-docs/v0/assets/images/final/filename.png)
+```
+
+Always use `![Click to enlarge]`. Images live in `assets/images/final/`.
+
+### Mermaid diagrams
+
+Mermaid diagrams are acceptable for workflow/decision flow concepts:
+
+```
+```mermaid
+flowchart TD
+    A["input"] --> B["step 1"] --> C["output"]
+```
+```
+
+---
+
+## Filled template — copy and adapt
+
+The following is a starting scaffold. Delete or add H2 sections as needed for the topic.
+
+```markdown
+---
+title: Concept name
+excerpt: ''
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: 'Short phrase describing the concept'
+  robots: index
+next:
+  description: ''
+---
+[Opening paragraph: 1–4 sentences defining the concept and why it matters.]
+
+## [Main concept section]
+
+[Explanation, steps, or examples. Add more H2s as needed.]
+
+## [Second concept section]
+
+[Continue as needed.]
+
+## Notes
+
+* [Optional: cross-references or edge-case callouts that don't fit above.]
+```
+
+---
+
+## File naming and registration
+
+- Filename: `kebab-case.md`, e.g., `anchor-nuances.md`, `field-order.md`
+- Location: `docs/Senseml reference/concepts/`
+- After writing the file, add the slug (filename without `.md`) to `docs/Senseml reference/concepts/_order.yaml`
+- No link needed in `index.md` — it just says "see child topics"

--- a/docs/Senseml reference/concepts/draft-idp.md
+++ b/docs/Senseml reference/concepts/draft-idp.md
@@ -1,0 +1,51 @@
+---
+title: Intelligent document processing
+excerpt: ''
+deprecated: false
+hidden: true
+metadata:
+  title: ''
+  description: 'Intelligent document processing with Sensible'
+  robots: index
+next:
+  description: ''
+---
+Intelligent document processing (IDP) automates the extraction of structured data from documents — PDFs, emails, spreadsheets, images, and more — so that downstream systems can consume and act on it. The core challenge of IDP is document variability: real-world documents range from rigidly templated tax forms to free-form legal contracts, and no single extraction technique handles both ends of that spectrum well.
+
+Sensible addresses this by combining two complementary extraction strategies in a single query language, [SenseML](doc:senseml-reference-introduction).
+
+## The document landscape
+
+Documents vary along two axes: **structure** (how consistently the layout is arranged) and **variability** (how many format revisions or issuer variations exist).
+
+At one extreme, a standard W-2 form has a predictable, fixed layout — the same fields appear in the same positions across issuers and years. At the other extreme, a legal contract from a new counterparty may be entirely free-form, with no fixed layout and no guaranteed field positions.
+
+Most business documents fall somewhere in between:
+
+![Click to enlarge](https://raw.githubusercontent.com/sensible-hq/sensible-docs/v0/assets/images/final/document_landscape.png)
+
+## Sensible's hybrid extraction approach
+
+Because no single technique covers the full document landscape, Sensible supports two extraction strategies that you can mix within the same config:
+
+| strategy | best suited for | characteristics |
+| -------- | --------------- | --------------- |
+| [LLM-based methods](doc:llm-based-methods) | Free-form, variable documents — legal contracts, clinical notes, open-ended forms | Describe what to extract in natural language. Handles layout variation automatically. Non-deterministic; suited to workflows with [human review](doc:human-review) or fault tolerance. |
+| [Layout-based methods](doc:layout-based-methods) | Structured, consistently formatted documents — tax forms, insurance declarations, bank statements | Target data by its position relative to anchor text and document layout. Deterministic and fast; suited to automated pipelines requiring predictable output. |
+
+When either approach works, Sensible recommends layout-based methods for their speed and deterministic output. When a document type spans both structured and unstructured variants, you can [mix strategies in the same config](doc:author) or use [fallback fields](doc:fallbacks) to chain them.
+
+## The IDP pipeline
+
+Sensible's platform covers the full IDP lifecycle, not just extraction. For a detailed breakdown of each stage, see [Devops platform](doc:devops-platform). At a high level:
+
+1. **Ingest** — Upload documents via API, SDK, bulk UI, or email. Sensible normalizes inputs into a standardized text representation and applies [OCR](doc:ocr) where needed.
+2. **Classify** — Documents are routed to a *document type* (a category like `bank_statements`) and automatically classified into a matching *config* (a subtype like `chase_statements`). Sensible uses [fingerprints](doc:fingerprint) and LLM-based classification to select the best config.
+3. **Extract** — SenseML queries run against the document and return structured JSON. Sensible includes an open-source [configuration library](doc:library-quickstart) with out-of-the-box support for common business forms.
+4. **Validate and monitor** — Write [validation rules](doc:validate-extractions) to catch extraction errors, track [extraction coverage](doc:coverage) and [accuracy](doc:accuracy-measures) in production, and route low-confidence extractions to [human review](doc:human-review).
+
+## Developer-first design
+
+Sensible is built for developers integrating document automation into applications. Extraction configs are JSON — version-controlled, testable, and deployable through Sensible's [CI/CD platform](doc:devops-platform). You interact with Sensible through a [REST API](doc:quickstart) or [Node/Python SDKs](doc:sdk-guides), and configs live alongside your application code.
+
+This design makes it practical to treat document extraction as a first-class software engineering problem: write configs, test against sample documents, review diffs in pull requests, and deploy to production with confidence.

--- a/docs/Senseml reference/concepts/draft-idp.md
+++ b/docs/Senseml reference/concepts/draft-idp.md
@@ -10,15 +10,15 @@ metadata:
 next:
   description: ''
 ---
-Intelligent document processing (IDP) automates the extraction of structured data from documents — PDFs, emails, spreadsheets, images, and more — so that downstream systems can consume and act on it. The core challenge of IDP is document variability: real-world documents range from rigidly templated tax forms to free-form legal contracts, and no single extraction technique handles both ends of that spectrum well.
+Intelligent document processing (IDP) automates extracting structured data from documents so that business systems can consume and act on it. The core challenge of IDP is document variability. In terms of content, documents range from highly templated tax forms to free-form legal contracts, and no single extraction technique handles both ends of that spectrum well.  In terms of file format, PDFs, emails, spreadsheets, and images present varying OCR and processing speed challenges.
 
-Sensible addresses this by combining two complementary extraction strategies in a single query language, [SenseML](doc:senseml-reference-introduction).
+Sensible addresses these challenges by combining two complementary extraction strategies in a single query language, [SenseML](doc:senseml-reference-introduction).
 
 ## The document landscape
 
-Documents vary along two axes: **structure** (how consistently the layout is arranged) and **variability** (how many format revisions or issuer variations exist).
+Document content varies along two axes: **structure** (how consistently the layout is arranged) and **variability** (how many format revisions or issuer variations exist).
 
-At one extreme, a standard W-2 form has a predictable, fixed layout — the same fields appear in the same positions across issuers and years. At the other extreme, a legal contract from a new counterparty may be entirely free-form, with no fixed layout and no guaranteed field positions.
+At one extreme, a standard W-2 form has a predictable, fixed layout. The same fields appear in the same positions across issuers and years. At the other extreme, a legal contract from a new counterparty may be entirely free form, with no fixed layout and no guaranteed field positions.
 
 Most business documents fall somewhere in between:
 
@@ -26,7 +26,7 @@ Most business documents fall somewhere in between:
 
 ## Sensible's hybrid extraction approach
 
-Because no single technique covers the full document landscape, Sensible supports two extraction strategies that you can mix within the same config:
+Because no single technique covers the full document landscape, Sensible supports two extraction strategies that you can mix within the same extraction config:
 
 | strategy | best suited for | characteristics |
 | -------- | --------------- | --------------- |
@@ -39,8 +39,8 @@ When either approach works, Sensible recommends layout-based methods for their s
 
 Sensible's platform covers the full IDP lifecycle, not just extraction. For a detailed breakdown of each stage, see [Devops platform](doc:devops-platform). At a high level:
 
-1. **Ingest** — Upload documents via API, SDK, bulk UI, or email. Sensible normalizes inputs into a standardized text representation and applies [OCR](doc:ocr) where needed.
-2. **Classify** — Documents are routed to a *document type* (a category like `bank_statements`) and automatically classified into a matching *config* (a subtype like `chase_statements`). Sensible uses [fingerprints](doc:fingerprint) and LLM-based classification to select the best config.
+1. **Ingest** — You upload documents via API, SDK, bulk UI, or email. Sensible normalizes inputs into a standardized text representation and applies [OCR](doc:ocr) where needed.
+2. **Classify** — Sensible routes documents to a *document type* (a category like `bank_statements`) and automatically classified into a matching *config* (a subtype like `chase_statements`). Sensible uses [fingerprints](doc:fingerprint) and LLM-based classification to select the best config.
 3. **Extract** — SenseML queries run against the document and return structured JSON. Sensible includes an open-source [configuration library](doc:library-quickstart) with out-of-the-box support for common business forms.
 4. **Validate and monitor** — Write [validation rules](doc:validate-extractions) to catch extraction errors, track [extraction coverage](doc:coverage) and [accuracy](doc:accuracy-measures) in production, and route low-confidence extractions to [human review](doc:human-review).
 


### PR DESCRIPTION
## Summary

- Adds a new `create-concept-doc` Claude Code skill for authoring concept pages under `docs/Senseml reference/concepts/`
- Adds `concept-topic-template.md` to `.claude/style-guide/`, seeded from analysis of 6 existing concept pages

The new skill is intentionally distinct from `create-new-doc` (which is PR-driven and targets reference pages). `create-concept-doc` takes a concept name + free-form notes as input, selects structurally similar existing pages to read for conventions, and produces a free-form H2-structured page with `_order.yaml` registration.

## Test plan

- [ ] Invoke `/create-concept-doc` with a sample concept name and verify skill triggers correctly
- [ ] Check that the skill description distinguishes it clearly from `create-new-doc` in the skills picker
- [ ] Review `concept-topic-template.md` for accuracy against existing concept pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)