### PR TITLE
chore: add editorial rules to style guides

### DIFF
--- a/.claude/style-guide/sentence-word-guidance.md
+++ b/.claude/style-guide/sentence-word-guidance.md
@@ -68,6 +68,20 @@ When a method's table lists a global param for completeness, use this shorthand 
 
 ---
 
+## Sentence construction
+
+**Prefer gerunds over nominalizations.** Use the verb form directly rather than a noun derived from it.
+- Avoid: "automates the extraction of structured data"
+- Prefer: "automates extracting structured data"
+
+**Use explicit subjects in numbered steps.** Don't use imperative or passive voice in numbered-step lists. Use "You" for user actions and "Sensible" for platform behavior.
+- Avoid: "Upload documents via API, SDK, or email."
+- Avoid: "Documents are routed to a document type."
+- Prefer: "You upload documents via API, SDK, or email."
+- Prefer: "Sensible routes documents to a document type."
+
+---
+
 ## Terminology: use these words consistently
 
 | Concept | Use this term | Avoid |
@@ -81,6 +95,8 @@ When a method's table lists a global param for completeness, use this shorthand 
 | A defined extraction unit | "field" | "extraction", "key" |
 | Repeated document structures | "sections" | "repeating groups", "loops" |
 | An extraction that returned nothing | "null" | "empty", "undefined", "no value" |
+| Unstructured/variable documents (adjective before noun) | "free-form documents", "a free-form contract" | "free form documents" |
+| Unstructured/variable documents (predicate adjective) | "the document is free form", "entirely free form" | "entirely free-form" |
 | The Sensible product | "Sensible" (always capitalized) | "sensible", "the tool", "the engine" |
 | The document excerpt Sensible renders visually | "the Sensible app" | "the UI", "the editor" |
 | JSON path into extracted output | "dot notation" (e.g., `claims.columns.3.values`) | "object path", "key path" |

--- a/.claude/style-guide/style-guide-overview.md
+++ b/.claude/style-guide/style-guide-overview.md
@@ -81,6 +81,10 @@ Do not start with "The X method..." as a default. Lead with what it does.
 
 **Tone:** Terse and precise. No filler. No "please note that" or "it's important to remember". State facts directly.
 
+**Em dashes:** Do not use em dashes to join compound clauses. Split them into two sentences instead.
+- Avoid: "a fixed layout — the same fields appear in the same positions across issuers."
+- Prefer: "a fixed layout. The same fields appear in the same positions across issuers."
+
 ---
 
 ## Parameter table formats


### PR DESCRIPTION
## Summary

Adds four editorial rules derived from corrections made to the IDP concept draft:

- **Em dashes** — don't use to join compound clauses; split into two sentences instead
- **Gerunds over nominalizations** — "automates extracting" not "automates the extraction of"
- **Explicit subjects in numbered steps** — use "You" for user actions, "Sensible" for platform behavior; avoid imperative or passive
- **"free form" hyphenation** — hyphenate before a noun ("free-form document"), no hyphen as predicate adjective ("entirely free form")

## Test plan

- [ ] Spot-check that the new sentence construction rules are consistent with existing pages
- [ ] Confirm the free-form hyphenation examples match usage in existing docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)