### PR TITLE
chore: add sensible-changelog skill and changelog style guide

### DIFF
--- a/.claude/skills/sensible-changelog/SKILL.md
+++ b/.claude/skills/sensible-changelog/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: sensible-changelog
+description: Generates and publishes a monthly Sensible product changelog. Invoke whenever the user wants to write, draft, or publish a monthly changelog, or mentions writing up a release summary given a list of PRs. The user will provide PR numbers (from the frontend or backend GitHub repo, or both) and optionally a list of doc topic URLs. The skill structures the input, fetches PR context, drafts the changelog in Sensible's house style, gets user approval, then publishes as a hidden draft to readme.com.
+---
+
+# Sensible Changelog Skill
+
+## Repos
+
+- **Backend**: `sensible-hq/sensible`
+- **Frontend**: `sensible-hq/sensible-app`
+- **Docs**: `sensible-hq/sensible-docs`
+
+---
+
+## Step 1: Parse input, fetch PR titles, confirm with user
+
+The user will paste an unstructured blob. It may contain any mix of:
+- PR numbers from the backend or frontend repo (possibly labeled "frontend"/"backend")
+- PR numbers from the docs repo (`sensible-docs`) — labeled "docs" or inferrable from context
+- Doc topic URLs (`https://docs.sensible.so/...`)
+- Pasted doc content (raw markdown or prose the user has copied directly)
+
+**1a. Parse** out each of these. For PR numbers:
+- If labeled by repo, use that. If unlabeled, try fetching from all three repos in parallel and use whichever returns a valid result. If still ambiguous, ask.
+
+For pasted doc content: treat it as the user-facing description for the associated feature — note it in the summary as "pasted content" so the user can see it was captured.
+
+**1b. Fetch PR titles immediately** — run in parallel so the confirmation summary is useful:
+```bash
+gh pr view <number> --repo <org/repo> --json number,title,mergedAt
+```
+
+**1c. Present a structured summary** for the user to review before any further work:
+
+```
+## Input summary — please confirm before I continue
+
+**PRs:**
+- [#1234](https://github.com/sensible-hq/sensible/pull/1234) — backend — "Add Remove Lines preprocessor"
+- [#567](https://github.com/sensible-hq/sensible-app/pull/567) — frontend — "Batch document upload UI"
+- [#89](https://github.com/sensible-hq/sensible-docs/pull/89) — docs — "Add remove-lines reference page"
+
+**Doc topics:**
+- https://docs.sensible.so/docs/remove-lines
+- Pasted content: "The Remove Lines preprocessor removes matched text from all pages…"
+
+**Skipping (no user-facing changes):**
+- [#890](https://github.com/sensible-hq/sensible/pull/890) — "Refactor auth middleware" — infra only
+
+Proceed?
+```
+
+Wait for confirmation before continuing.
+
+---
+
+## Step 2: Fetch full PR context
+
+For each confirmed PR, fetch the full body:
+```bash
+gh pr view <number> --repo <org/repo> --json title,body,mergedAt,labels
+```
+
+From the body, extract:
+- What changed (the "what")
+- Why it matters or how users use it (the "so what")
+- Any linked doc pages or feature names
+
+Ignore boilerplate (checklists, "how to test", internal notes). Focus on user-facing description.
+
+**Non-user-facing PRs**: If a PR is clearly infra-only, a refactor, a test change, or has no user-visible effect, skip it from the changelog. Note it in the summary you showed in Step 1 (under "Skipping") so the user knows it was considered and excluded intentionally.
+
+---
+
+## Step 3: Source feature descriptions
+
+For each changelog entry, use the best available source. Priority order:
+
+1. **Pasted doc content** — if the user pasted doc text directly, use it as-is. It's already user-facing.
+2. **Docs PR** — fetch the PR body and diff for the most accurate user-facing description:
+   ```bash
+   gh pr view <number> --repo sensible-hq/sensible-docs --json title,body,files
+   gh pr diff <number> --repo sensible-hq/sensible-docs
+   ```
+   The diff shows exactly what was added to the docs — use the added lines (`+`) as the primary source.
+3. **Doc URL → local file** — derive the path from the slug directly:
+   ```
+   https://docs.sensible.so/docs/remove-lines → slug = "remove-lines"
+   Check: /home/franceselliott/GitHub/sensible-docs/docs/remove-lines.md
+          /home/franceselliott/GitHub/sensible-docs/reference/remove-lines.md
+   ```
+4. **Code PR body** — use the user-facing description from the backend/frontend PR.
+5. **MCP fallback** — `mcp__sensible-docs__search` with the feature name. Least reliable; use only if nothing else is available.
+
+The goal is accurate, user-facing language — not copying the doc verbatim or paraphrasing internal PR descriptions.
+
+---
+
+## Step 4: Draft the changelog
+
+Read `/home/franceselliott/GitHub/sensible-docs/.claude/style-guide/changelog-style-guide.md` for the full style reference, voice guidelines, and examples before drafting.
+
+Key reminders:
+- Intro paragraph: third person ("Sensible released…"), no doc links
+- Section headings: `## New feature:`, `## Improvement:`, `## UX improvement:`, `## UX improvements:`, `## Deprecation:` — use exactly these strings
+- Section bodies: second person, 2–5 sentences, prose over bullets
+- Doc links: `[text](doc:slug)` format
+- Lead with the most significant features
+
+---
+
+## Step 5: Review with user
+
+Print the full draft. Ask:
+> "Does this look right? Any edits before I publish?"
+
+Incorporate feedback. Do not publish until the user explicitly approves.
+
+---
+
+## Step 6: Publish as hidden draft
+
+Once approved, write the body to a temp file and run `scripts/publish_changelog.py`:
+
+```bash
+cat > /tmp/changelog_body.txt << 'CHANGELOG_EOF'
+<paste full body here>
+CHANGELOG_EOF
+
+python /home/franceselliott/.claude/skills/sensible-changelog/scripts/publish_changelog.py "March 2026" < /tmp/changelog_body.txt
+```
+
+The script handles auth, the POST request, and prints the draft URL on success or the full error on failure.

--- a/.claude/skills/sensible-changelog/scripts/publish_changelog.py
+++ b/.claude/skills/sensible-changelog/scripts/publish_changelog.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Publishes a changelog to readme.com as a hidden draft.
+
+Usage:
+    echo "$BODY" | python publish_changelog.py "March 2026"
+
+Reads the changelog body from stdin, title from argv[1].
+Requires README_API_KEY env var (sources ~/.bashrc if not set).
+
+Prints the draft URL on success, full error response on failure.
+"""
+
+import sys
+import os
+import base64
+import json
+import subprocess
+import urllib.request
+import urllib.error
+
+
+def get_api_key():
+    key = os.environ.get("README_API_KEY")
+    if key:
+        return key
+    # Try sourcing ~/.bashrc
+    result = subprocess.run(
+        ["bash", "-c", "source ~/.bashrc 2>/dev/null && echo $README_API_KEY"],
+        capture_output=True, text=True
+    )
+    key = result.stdout.strip()
+    if not key:
+        print("ERROR: README_API_KEY not set. Set it in ~/.bashrc and re-run.", file=sys.stderr)
+        sys.exit(1)
+    return key
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: echo \"$BODY\" | python publish_changelog.py \"March 2026\"", file=sys.stderr)
+        sys.exit(1)
+
+    title = sys.argv[1]
+    body = sys.stdin.read().strip()
+
+    if not body:
+        print("ERROR: changelog body is empty (nothing on stdin)", file=sys.stderr)
+        sys.exit(1)
+
+    api_key = get_api_key()
+    auth = base64.b64encode(f"{api_key}:".encode()).decode()
+
+    payload = json.dumps({
+        "title": title,
+        "body": body,
+        "hidden": True
+    }).encode()
+
+    req = urllib.request.Request(
+        "https://dash.readme.com/api/v1/changelogs",
+        data=payload,
+        headers={
+            "Authorization": f"Basic {auth}",
+            "Content-Type": "application/json",
+        },
+        method="POST"
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            result = json.loads(resp.read())
+            slug = result.get("slug", "")
+            print(f"Published (hidden draft): https://dash.readme.com/project/sensible/v2.0/changelog/{slug}")
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        print(f"ERROR {e.code}: {error_body}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/style-guide/changelog-style-guide.md
+++ b/.claude/style-guide/changelog-style-guide.md
@@ -1,0 +1,124 @@
+# Sensible Changelog Style Guide
+
+Derived from analysis of published changelogs (2024–2026). Use this to calibrate tone, structure, and voice when writing a monthly product changelog.
+
+---
+
+## Voice and tone
+
+- **Intro paragraph**: Third person — "Sensible released", "Sensible added", "Sensible improved". Not "we released".
+- **Section bodies**: Second person — "you can now", "use this to", "for example, you can configure".
+- **Factual, present tense**: Describe what the feature does, not what was built. "You can now extract…" not "We built extraction for…"
+- **No marketing fluff**: No "excited to announce", no "powerful new", no "seamlessly". Just what it does and why it's useful.
+
+---
+
+## Structure
+
+### Title
+`Month YYYY` (e.g., `March 2026`)
+
+### Intro paragraph (no heading)
+One paragraph, pattern: `"In the last month, Sensible [summary of 2–4 highlights]."`
+
+- No doc links
+- Mentions the most significant changes
+- Neutral and factual
+
+**Examples:**
+> In the last month, Sensible added deterministic methods for removing unwanted text from documents and for matching rotated text, such as watermarks. We also added advanced transformation logic for large spreadsheet extractions.
+
+> In the last month, Sensible released several major new features. We introduced email-driven document extraction for automated processing of email attachments, significantly expanded our auto-generated extraction schemas to handle larger and more complex documents, and added new troubleshooting capabilities for multimodal extractions.
+
+### Sections
+One section per feature (or group closely related items):
+
+```
+## [Type]: [Short descriptive title]
+
+Body text.
+```
+
+**Ordering**: Lead with the most significant features. Group by theme if it helps readability.
+
+---
+
+## Section heading types
+
+Use exactly these strings (casing matters):
+
+| Type | When to use |
+|------|-------------|
+| `New feature:` | Net-new functionality that didn't exist before |
+| `Improvement:` | New config option or enhancement to existing feature |
+| `UX improvement:` | Single UI/UX change in the Sensible app |
+| `UX improvements:` | Multiple UI/UX changes grouped in one section |
+| `Deprecation:` | Something being deprecated or removed |
+
+**Do not use** `Update:` — phased out as of 2025.
+
+---
+
+## Section body
+
+- 2–5 sentences, prose style
+- Use bullets only when listing multiple parallel sub-items
+- First sentence: what was added or changed
+- Subsequent sentences: usage context, an example, or what problem it solves
+
+**Short improvement:**
+> With the new [Remove Lines](doc:remove-lines) preprocessor, you can now remove matched text from all pages in a document. For example, use this preprocessor to remove watermarks or page numbers. This preprocessor is an alternative to the Remove Header and Remove Footer preprocessors and can remove text that varies in position on the page.
+
+**Improvement with inline code:**
+> When you want to match the nth occurrence of a string or regular expression, the new Repeat match object is a more concise alternative to a [match array](doc:match-arrays). For example, to find the fifth occurrence of "customer account", you can specify:
+> ```json
+> "match": [{ "type": "repeat", "times": 5, "match": { "type": "startsWith", "text": "customer account" } }]
+> ```
+
+**Feature with bulleted sub-items:**
+> Sensible added support for automated extraction from email documents. Key features include:
+> * LLM-based attachment classification against specified document types
+> * Support for multiple attachments per email
+> * Optional email body extraction
+> * Webhook delivery of extraction results with metadata and download links
+
+---
+
+## Doc links
+
+readme short-link format — not full URLs:
+
+```
+[link text](doc:slug)
+```
+
+Derive the slug from the URL's last path segment:
+- `https://docs.sensible.so/docs/remove-lines` → `(doc:remove-lines)`
+- `https://docs.sensible.so/docs/query-group` → `(doc:query-group)`
+
+For `#` anchors, append them: `(doc:match#global-parameters)`
+
+---
+
+## Images
+
+Always use JSX `<Image>` (not markdown `![alt](url)`):
+
+```jsx
+<Image alt="Click to enlarge" border={false} src="URL" />
+```
+
+Only include images if URLs are explicitly provided. No trailing `<br />` unless it immediately precedes an image.
+
+---
+
+## Length calibration
+
+| Feature type | Typical length |
+|---|---|
+| Simple config param | 2–3 sentences |
+| New method or preprocessor | 3–5 sentences, possibly with code example |
+| Major UX feature | Longer, multiple images and sub-bullets OK |
+| Deprecation | 1–2 sentences, link to replacement |
+
+A typical changelog has 3–6 sections.


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/sensible-changelog/` — a new skill for drafting and publishing monthly product changelogs given a list of PRs and doc topic URLs
- Adds `.claude/style-guide/changelog-style-guide.md` — static style guide derived from analysis of 12+ existing changelogs (2024–2026)

## Skill behavior

1. Parses unstructured input (PR numbers from backend/frontend/docs repos + doc URLs + pasted content), fetches PR titles in parallel, and prints a structured summary for review
2. Fetches full PR context and doc content (priority: pasted content → docs PR diff → local file → MCP)
3. Drafts changelog in Sensible's house style
4. Gets user approval before publishing
5. Publishes as hidden draft to readme via `scripts/publish_changelog.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)