### PR TITLE
chore: consolidate terminology into canonical glossary

### DIFF
--- a/.claude/style-guide/glossary.md
+++ b/.claude/style-guide/glossary.md
@@ -1,0 +1,37 @@
+# Sensible Docs Terminology Glossary
+
+Canonical term reference for all Sensible documentation. When writing or reviewing any doc — reference pages, changelogs, integration guides, concept topics — use these terms consistently.
+
+Organized in two sections:
+- **Universal terms** — apply to all Sensible content
+- **SenseML-specific terms** — apply when writing or updating SenseML reference pages
+
+---
+
+## Universal terms
+
+| Concept | Use | Avoid | Notes |
+| ------- | --- | ----- | ----- |
+| The JSON extraction configuration | "config" or "configuration" | "template", "schema" | "schema" has a specific meaning in the product |
+| The Sensible web interface | "the Sensible app" | "the UI", "the editor", "the dashboard" | |
+| The Sensible product | "Sensible" (always capitalized) | "sensible", "the tool", "the engine" | |
+| The result Sensible returns | "output", "extracted field", "field" | "result object", "response" | "response" refers to the API response envelope |
+| Repeated document structures | "sections" | "repeating groups", "loops" | |
+| An extraction that returned nothing | "null" | "empty", "undefined", "no value" | |
+
+---
+
+## SenseML-specific terms
+
+These apply when writing SenseML reference pages (methods, preprocessors, computed field methods, the anchor and match objects).
+
+| Concept | Use | Avoid | Notes |
+| ------- | --- | ----- | ----- |
+| The text Sensible matches to find a location | "anchor", "anchor line", "anchor point" | "reference text", "marker" | |
+| The document text sent to an LLM | "context" | "prompt context", "input" | |
+| A scored portion of the document for LLM use | "chunk" | "segment", "section" | "section" has a specific SenseML meaning |
+| The SenseML data output type | "type" (e.g., "currency type", "date type") | "data type", "field type" | |
+| A defined extraction unit | "field" | "extraction", "key" | |
+| JSON path into extracted output | "dot notation" (e.g., `claims.columns.3.values`) | "object path", "key path" | |
+| Unstructured/variable documents — adjective before noun | "free-form documents", "a free-form contract" | "free form documents" | hyphenate when preceding a noun |
+| Unstructured/variable documents — predicate adjective | "the document is free form", "entirely free form" | "entirely free-form" | no hyphen in predicate position |

--- a/.claude/style-guide/sentence-word-guidance.md
+++ b/.claude/style-guide/sentence-word-guidance.md
@@ -82,24 +82,9 @@ When a method's table lists a global param for completeness, use this shorthand 
 
 ---
 
-## Terminology: use these words consistently
+## Terminology
 
-| Concept | Use this term | Avoid |
-| ------- | ------------- | ----- |
-| The JSON configuration file | "config" or "configuration" | "template", "schema" (schema has a specific meaning) |
-| The result Sensible returns | "output", "extracted field", "field" | "result object", "response" (that's the API response) |
-| The text Sensible matches to find a location | "anchor", "anchor line", "anchor point" | "reference text", "marker" |
-| The document text sent to an LLM | "context" | "prompt context", "input" |
-| A scored portion of the document for LLM use | "chunk" | "segment", "section" (has a specific SenseML meaning) |
-| The SenseML data output type | "type" (e.g., "currency type", "date type") | "data type", "field type" |
-| A defined extraction unit | "field" | "extraction", "key" |
-| Repeated document structures | "sections" | "repeating groups", "loops" |
-| An extraction that returned nothing | "null" | "empty", "undefined", "no value" |
-| Unstructured/variable documents (adjective before noun) | "free-form documents", "a free-form contract" | "free form documents" |
-| Unstructured/variable documents (predicate adjective) | "the document is free form", "entirely free form" | "entirely free-form" |
-| The Sensible product | "Sensible" (always capitalized) | "sensible", "the tool", "the engine" |
-| The document excerpt Sensible renders visually | "the Sensible app" | "the UI", "the editor" |
-| JSON path into extracted output | "dot notation" (e.g., `claims.columns.3.values`) | "object path", "key path" |
+See [glossary.md](glossary.md) for the canonical term reference. Both the universal terms and the SenseML-specific terms apply to reference pages.
 
 ---
 

--- a/.claude/style-guide/writing-rules.md
+++ b/.claude/style-guide/writing-rules.md
@@ -41,16 +41,7 @@ Use the verb form directly rather than a noun derived from it.
 
 ## Terminology
 
-Use these terms consistently across all content:
-
-| Concept | Use | Avoid |
-|---------|-----|-------|
-| The JSON extraction configuration | "config" or "configuration" | "template", "schema" |
-| The Sensible web interface | "the Sensible app" | "the UI", "the editor", "the dashboard" |
-| The Sensible product | "Sensible" (always capitalized) | "sensible", "the tool", "the engine" |
-| The result Sensible returns | "output", "extracted field" | "result object", "response" |
-| Repeated document structures | "sections" | "repeating groups", "loops" |
-| An extraction that returned nothing | "null" | "empty", "undefined", "no value" |
+See [glossary.md](glossary.md) for the canonical term reference. Apply the universal terms to all content; apply SenseML-specific terms when writing reference pages.
 
 ---
 


### PR DESCRIPTION
## Summary
- Created `.claude/style-guide/glossary.md` as the single source of truth for Sensible terminology (14 terms, split into universal and SenseML-specific)
- Removed duplicate term tables from `writing-rules.md` and `sentence-word-guidance.md`; replaced with pointers to the glossary
- Resolved two inconsistencies between the old tables: added "the dashboard" to the Sensible app avoid list, unified the extracted field term list to include "field" as a valid option

## Test plan
- [ ] Verify `glossary.md` contains all terms previously in both source files with no omissions
- [ ] Verify `writing-rules.md` and `sentence-word-guidance.md` no longer contain term tables and correctly reference the glossary

🤖 Generated with [Claude Code](https://claude.com/claude-code)