### PR TITLE
chore: add Vale config, sandboxed Chrome script, style guide updates

### DIFF
--- a/.claude/style-guide/style-guide-overview.md
+++ b/.claude/style-guide/style-guide-overview.md
@@ -156,6 +156,28 @@ This applies even though the JSON key is camelCase (`sortLines`, `textAlignment`
 ### Method and feature names in prose
 Capitalize method names and major feature names: "the Label method", "the Box method", "the Region method", "the Query Group method", "Sections", "the Multicolumn preprocessor", "the Merge Lines preprocessor".
 
+**Never use camelCase with backticks for method or preprocessor names in running prose.** Convert to spaced Title Case instead:
+
+| Wrong | Right |
+| ----- | ----- |
+| the `` `customCompute` `` method | the Custom Compute method |
+| the `` `removeHeaders` `` preprocessor | the Remove Headers preprocessor |
+| the `` `queryGroup` `` method | the Query Group method |
+| the `` `mergeLines` `` preprocessor | the Merge Lines preprocessor |
+
+This applies to parameter names too — see the Parameter name capitalization section above.
+
+### Inline links for method and preprocessor names
+
+Where possible, link method and preprocessor names inline on first mention. Use `doc:` slugs (not `.md` file paths). To find the correct slug for a page, consult [https://docs.sensible.so/llms.txt](https://docs.sensible.so/llms.txt) and use the slug portion of the URL (the part after `docs.sensible.so/`), **without** the `.md` extension.
+
+Examples:
+- `[Custom Compute method](doc:custom-compute)`
+- `[Remove Headers preprocessor](doc:remove-headers)`
+- `[Query Group method](doc:query-group)`
+
+Link on first meaningful mention per page. Do not re-link on every subsequent mention.
+
 ---
 
 ## Image format

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,6 @@
+StylesPath = .github/styles
+
+Vocab = Sensible
+
+[*.md]
+BasedOnStyles = Vale

--- a/scripts/docker-chrome-claude.sh
+++ b/scripts/docker-chrome-claude.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── Configuration ──────────────────────────────────────────────────────────────
+CONTAINER_NAME="sandboxed-chrome"
+PORT=6901
+SANDBOXED_CHROME_PASSWORD="${SANDBOXED_CHROME_PASSWORD:?Set SANDBOXED_CHROME_PASSWORD env variable before running this script}"
+VOLUME_NAME="sandboxed-chrome-profile"
+
+# ─── Colors ─────────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# ─── Preflight checks ──────────────────────────────────────────────────────────
+command -v docker >/dev/null 2>&1 || error "Docker is not installed. Install it first: https://docs.docker.com/get-docker/"
+
+if ! docker info >/dev/null 2>&1; then
+    error "Docker daemon is not running. Start Docker Desktop or the Docker service."
+fi
+
+# ─── Handle existing container ──────────────────────────────────────────────────
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+        warn "Container '${CONTAINER_NAME}' is already running."
+        info "Access it at: https://localhost:${PORT}"
+        info "To stop it:   docker stop ${CONTAINER_NAME}"
+        info "To remove it: docker rm ${CONTAINER_NAME}"
+        exit 0
+    else
+        info "Removing stopped container '${CONTAINER_NAME}'..."
+        docker rm "${CONTAINER_NAME}" >/dev/null
+    fi
+fi
+
+# ─── Pull image ────────────────────────────────────────────────────────────────
+IMAGE="kasmweb/chrome:1.16.1"
+info "Pulling ${IMAGE} (this may take a few minutes the first time)..."
+docker pull "${IMAGE}"
+
+# ─── Create persistent volume ──────────────────────────────────────────────────
+if ! docker volume ls --format '{{.Name}}' | grep -q "^${VOLUME_NAME}$"; then
+    info "Creating persistent volume '${VOLUME_NAME}' for Chrome profile..."
+    docker volume create "${VOLUME_NAME}" >/dev/null
+fi
+
+# ─── Run container ──────────────────────────────────────────────────────────────
+info "Starting sandboxed Chrome container..."
+docker run -d \
+    --name "${CONTAINER_NAME}" \
+    --shm-size=2g \
+    -p "${PORT}:6901" \
+    -e VNC_PW="${SANDBOXED_CHROME_PASSWORD}" \
+    -v "${VOLUME_NAME}:/home/kasm-user/.config/chromium" \
+    "${IMAGE}" >/dev/null
+
+# ─── Wait for container to be ready ────────────────────────────────────────────
+info "Waiting for noVNC to start..."
+for i in $(seq 1 30); do
+    if curl -sk "https://localhost:${PORT}" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+# ─── Done ───────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}════════════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN} Sandboxed Chrome is running!${NC}"
+echo -e "${GREEN}════════════════════════════════════════════════════════════════${NC}"
+echo ""
+echo -e " URL:       ${YELLOW}https://localhost:${PORT}${NC}"
+echo -e " Password:  ${YELLOW}${SANDBOXED_CHROME_PASSWORD}${NC}"
+echo ""
+echo -e " ${GREEN}Next steps:${NC}"
+echo -e "  1. Open the URL above in your browser (accept the self-signed cert)"
+echo -e "  2. Log in with the password above"
+echo -e "  3. Inside the sandboxed Chrome, go to the Chrome Web Store"
+echo -e "  4. Search for and install the Claude extension"
+echo -e "  5. The extension persists across restarts (profile is on a volume)"
+echo ""
+echo -e " ${GREEN}Management:${NC}"
+echo -e "  Stop:     docker stop ${CONTAINER_NAME}"
+echo -e "  Start:    docker start ${CONTAINER_NAME}"
+echo -e "  Remove:   docker rm -f ${CONTAINER_NAME}"
+echo -e "  Nuke all: docker rm -f ${CONTAINER_NAME} && docker volume rm ${VOLUME_NAME}"
+echo ""


### PR DESCRIPTION
## Summary
- Add `.vale.ini` wiring Vale linter to existing `.github/styles` and `Sensible` vocab
- Add `scripts/docker-chrome-claude.sh` to spin up a sandboxed KasmWeb Chrome container with a persistent profile volume
- Expand style guide: method/preprocessor names in prose use Title Case not camelCase backticks; guidance on inline `doc:` slug links

## Test plan
- [ ] Vale linter picks up `.vale.ini` and runs against `*.md` files
- [ ] `docker-chrome-claude.sh` starts/stops the container cleanly; idempotent on re-run
- [ ] Style guide additions are clear and consistent with surrounding content

🤖 Generated with [Claude Code](https://claude.com/claude-code)