### PR TITLE
Add email processors API spec

### DIFF
--- a/.claude/skills/sensible-api-spec/SKILL.md
+++ b/.claude/skills/sensible-api-spec/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: sensible-api-spec
+description: Creates or updates OpenAPI JSON spec files in the /reference directory of sensible-docs, based on backend PRs from sensible-hq/sensible. Use this skill whenever the user provides PR numbers or GitHub URLs from the backend repo and wants to document new API endpoints, update existing endpoint schemas, or add new fields to an existing API reference. Also triggers when the user mentions "new API", "update the spec", "API reference from PRs", "write a spec for [feature]", or provides a list of PRs and asks to document them. This skill handles the end-to-end workflow: reading PRs, extracting API surface changes from diffs and Zod/TypeScript schemas, drafting OpenAPI 3.0.3 JSON, creating supporting markdown files, and updating _order.yaml navigation files.
+---
+
+# Sensible API Spec Skill
+
+**Docs repo**: `sensible-hq/sensible-docs` (local: `/home/franceselliott/GitHub/sensible-docs`)  
+**Backend repo**: `sensible-hq/sensible`  
+**Spec files**: `reference/openapi_*.json`  
+**New spec naming**: `reference/openapi_{domain}.json` (e.g., `openapi_email.json`)
+
+---
+
+## Step 1: Parse input, fetch PR titles, confirm
+
+Accept PR numbers or GitHub URLs from `sensible-hq/sensible`. Fetch titles in parallel:
+
+```bash
+gh pr view <number> --repo sensible-hq/sensible --json number,title,mergedAt
+```
+
+Present a structured summary before doing any more work:
+
+```
+## PRs — please confirm before I continue
+
+- [#3237](https://github.com/sensible-hq/sensible/pull/3237) — "email processors - endpoints - part 1" (merged 2026-02-17)
+- [#3242](https://github.com/sensible-hq/sensible/pull/3242) — "email processors - endpoints - part 2" (merged 2026-04-01)
+
+Proceed?
+```
+
+Wait for confirmation before continuing.
+
+---
+
+## Step 2: Fetch full PR context
+
+For each confirmed PR, fetch body and diff in parallel:
+
+```bash
+gh pr view <number> --repo sensible-hq/sensible --json title,body,mergedAt,labels
+gh pr diff <number> --repo sensible-hq/sensible
+```
+
+From body and diff, extract:
+- New route paths and HTTP methods (look for `.addRoute(`, handler files, router config)
+- Request body schemas (look for `schemas.ts`, Zod schema definitions, `z.object(`, `z.union(`, `z.discriminatedUnion(`)
+- Response shapes (look for `mappers.ts`, response type exports, integration test response body assertions)
+- New path/query/header parameters
+- New error codes and the conditions that trigger them
+- Changes to existing endpoints — new fields in request or response
+
+**The diff is the ground truth.** PR bodies explain intent; diffs show what actually shipped. When they conflict, trust the diff.
+
+**Skip**: import reordering, test helper utilities, CI config, internal refactors that don't change any route or schema.
+
+---
+
+## Step 3: Categorize changes and flag mixed PRs
+
+Sort each discovered change into one of three buckets:
+
+**New spec** — new route paths that don't exist in any current spec (e.g., `/processors/email/*`). These will become a new `openapi_{domain}.json` file.
+
+**Update existing spec** — new fields, parameters, or response codes added to routes already documented in an existing spec. Current specs and their route coverage:
+- `openapi_extraction.json` — `/extract/*`, `/generate_upload_url/*`, `/retrieve/*`
+- `openapi_classification.json` — `/classify/*`
+- `openapi_configuration.json` — `/document_types/*`, `/configurations/*`, `/reference_documents/*`
+- `sensible.json` — `/generate/*` (document generation), and miscellaneous account endpoints like `/account`
+
+**Mixed PR** — a single PR that does both. Flag this explicitly before proceeding:
+
+```
+⚠️  PR #3237 touches two categories:
+- New routes (/processors/email) → new spec: openapi_email.json
+- Existing endpoint (GET /account, adding fields: aliases, domain) → update sensible.json
+
+I'll handle both. Continuing...
+```
+
+After categorizing all PRs, state clearly:
+- Which new spec file(s) you'll create and what they'll contain
+- Which existing spec file(s) you'll update and what changes you'll make
+
+Ask for any corrections before drafting.
+
+---
+
+## Step 4: Read reference material before drafting
+
+Do this before writing a single line of the spec. Read in parallel.
+
+### 4a. Read an existing spec for JSON format reference
+
+For CRUD-style endpoint groups, `openapi_configuration.json` is the best model. For extraction-style async patterns, use `openapi_extraction.json`.
+
+JSON format patterns to carry forward consistently:
+- **OpenAPI version**: `3.0.3`
+- **Server**: `{"url": "https://api.sensible.so/v0", "description": "Production server (uses live data)"}`
+- **Security**: `bearerAuth` in `components.securitySchemes`, referenced via `security: [{bearerAuth: []}]`
+- **operationId**: kebab-case verb-noun (e.g., `get-email-processor`, `list-email-processors`, `upsert-email-processor`)
+- **Descriptions**: markdown prose, doc links in `doc:slug` format (e.g., `[quickstart](doc:quickstart)`)
+- **`$ref` components**: use for any schema referenced in more than one place
+- **Required fields**: declared in the parent `required: [...]` array, not inline
+- **Discriminated unions**: model with `oneOf` + `discriminator.propertyName`
+- **Error responses**: include at minimum 200, 400, and any endpoint-specific codes (403, 404, 409)
+
+### 4b. Read the Sensible prose style guides
+
+Read both files before drafting any descriptions or excerpt text:
+
+```
+/home/franceselliott/GitHub/sensible-docs/.claude/style-guide/writing-rules.md
+/home/franceselliott/GitHub/sensible-docs/.claude/style-guide/glossary.md
+```
+
+Also read the parameter description guidance in:
+```
+/home/franceselliott/GitHub/sensible-docs/.claude/style-guide/sentence-word-guidance.md
+```
+Focus on: "Parameter table: how to write each column" and "Sentence construction". The parameter table conventions don't apply literally (this isn't a SenseML page), but the underlying principles — lead with what it does, explicit subjects, gerunds over nominalizations — apply directly to OpenAPI schema property descriptions and endpoint `description` fields.
+
+---
+
+## Step 5: Draft the spec
+
+### For a new spec file
+
+Write the full OpenAPI 3.0.3 JSON. Structure:
+1. `openapi`, `servers`, `info`, `security` — top matter
+2. `tags` — one tag per logical group of endpoints
+3. `paths` — all new routes, each with operations for every supported method
+4. `components` — reusable schemas, parameters, request bodies, security scheme
+
+For discriminated union request bodies (e.g., `bodySpec`/`attachmentSpecs` with multiple `kind` values), use `oneOf` with a `discriminator`:
+
+```json
+"attachmentSpec": {
+  "oneOf": [
+    { "$ref": "#/components/schemas/SingleDocTypeSpec" },
+    { "$ref": "#/components/schemas/ClassificationSpec" },
+    { "$ref": "#/components/schemas/PortfolioSpec" }
+  ],
+  "discriminator": { "propertyName": "kind" }
+}
+```
+
+### For an update to an existing spec
+
+Locate the relevant path object and schema definitions. Add new fields to the right schema object. Don't remove or rename anything already present — existing clients depend on it.
+
+### Prose quality in descriptions
+
+Every `description` field in the spec and every `excerpt` in a markdown stub is published prose. Apply the style guides:
+
+- **Terminology** (`glossary.md`): "config" not "template" or "schema"; "output" not "result object"; "Sensible" always capitalized; "the Sensible app" not "the UI"; "null" not "empty"
+- **Subjects** (`writing-rules.md`): "Sensible [does X]" for platform behavior; "You [do Y]" for user actions; no passive constructions that hide the actor
+- **Gerunds** (`writing-rules.md`): "automates extracting" not "automates the extraction of"
+- **Em dashes** (`writing-rules.md`): split compound clauses into two sentences instead
+- **Lead with what it does** (`sentence-word-guidance.md`): start schema property descriptions with a verb or noun phrase — "Specifies the webhook URL", "The name of the processor" — not "This field..." or "Use this to..."
+- **Terse and precise**: no filler ("please note that", "it's important to remember")
+
+The `excerpt` in each markdown stub should be copied from the endpoint's `description` in the spec, not rewritten.
+
+### Showing the draft
+
+Present the full draft before writing any files. For specs longer than ~150 lines, show the structure summary and key sections (all path operations + main component schemas), then ask if the user wants to see the full JSON before you write it.
+
+---
+
+## Step 6: Review with user
+
+> "Does this look right? Any changes before I write the files?"
+
+Incorporate feedback. Do not write any files until the user explicitly approves.
+
+---
+
+## Step 7: Write files and update navigation
+
+### 7a. Write the spec
+
+For a new spec, write to `reference/openapi_{domain}.json`.  
+For an update, edit the specific object(s) in the existing spec file.
+
+### 7b. Create the endpoint markdown pages (new specs only)
+
+Each endpoint needs a markdown file so readme.com can render it. Follow this structure for a new domain (example: Email Processors):
+
+```
+reference/
+  Email Processors/
+    _order.yaml              ← lists subdirectory names
+    index.md                 ← group title page
+    email-processor/
+      _order.yaml            ← lists endpoint page filenames (no .md)
+      index.md               ← subgroup title page
+      list-email-processors.md
+      get-email-processor.md
+      upsert-email-processor.md
+      delete-email-processor.md
+```
+
+Each endpoint markdown page uses this frontmatter:
+
+```markdown
+---
+title: <Human-readable endpoint title>
+excerpt: >
+  <One or two sentence description of what this endpoint does.>
+api:
+  file: openapi_{domain}.json
+  operationId: <operationId from the spec>
+hidden: false
+---
+```
+
+The `excerpt` here should match the `description` in the spec — copy it, don't paraphrase.
+
+`index.md` files just need `title` and `hidden`:
+
+```markdown
+---
+title: Email processors
+hidden: false
+---
+```
+
+### 7c. Update `_order.yaml` files
+
+**New top-level section**: Add the new directory name to `reference/_order.yaml`. Ask the user where in the ordering it should appear before writing.
+
+**New subdirectory**: Create `reference/{Section}/_order.yaml` listing subdirectory names.
+
+**New endpoint group**: Create `reference/{Section}/{group}/_order.yaml` listing endpoint page filenames (without `.md` extension).
+
+Read `reference/_order.yaml` before editing to see current ordering:
+
+```bash
+cat /home/franceselliott/GitHub/sensible-docs/reference/_order.yaml
+```
+
+---
+
+## Quick reference: directory structure example
+
+Look at `reference/Classification/` as the simplest existing example:
+- `reference/Classification/_order.yaml` → `[document]`
+- `reference/Classification/document/_order.yaml` → `[classify-document, classify-document-sync]`
+- `reference/Classification/document/classify-document.md` → frontmatter with `api.file` + `api.operationId`
+- `reference/Classification/document/index.md` → just title
+
+Mirror this pattern for new sections.

--- a/.claude/skills/sensible-api-spec/evals/evals.json
+++ b/.claude/skills/sensible-api-spec/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "sensible-api-spec",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I want to create a new openapi spec for the email processors API. here are the PRs: https://github.com/sensible-hq/sensible/pull/3237 https://github.com/sensible-hq/sensible/pull/3190 https://github.com/sensible-hq/sensible/pull/3242 https://github.com/sensible-hq/sensible/pull/3287",
+      "expected_output": "Fetches all 4 PRs, presents a confirmation summary, categorizes changes (new spec for /processors/email/* routes, update to sensible.json for GET /account new fields), flags the mixed PR, drafts a new openapi_email.json with all 4 CRUD endpoints and correct schemas, creates supporting markdown files and _order.yaml entries, and writes everything after user approval.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "update the API reference from PR 3242 only — https://github.com/sensible-hq/sensible/pull/3242",
+      "expected_output": "Fetches PR 3242, identifies it as the full email processor CRUD implementation, correctly extracts the Zod schemas to define EmailProcessorInput (webhooks, bodySpec, attachmentSpecs discriminated union) and EmailProcessorOutput (same + name), drafts a spec for the 4 endpoints, gets approval, and writes the files.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "there's a new field being added to the extraction response in https://github.com/sensible-hq/sensible/pull/3300 — can you update the spec for that",
+      "expected_output": "Fetches PR 3300, identifies it as an update to an existing endpoint in openapi_extraction.json, locates the correct response schema in the existing spec, adds the new field, presents the diff, and writes the update after approval. Does not create new files.",
+      "files": []
+    }
+  ]
+}

--- a/postman/Sensible.postman_collection.json
+++ b/postman/Sensible.postman_collection.json
@@ -1,0 +1,1603 @@
+{
+  "info": {
+    "_postman_id": "45339059-3fec-4c31-a891-9a12a3e1c22b",
+    "name": "Sensible",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "16839934",
+    "_collection_link": "https://go.postman.co/collection/16839934-45339059-3fec-4c31-a891-9a12a3e1c22b?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "EXTRACTION",
+      "item": [
+        {
+          "name": "Document",
+          "item": [
+            {
+              "name": "Extract data from document",
+              "protocolProfileBehavior": {
+                "disabledSystemHeaders": {}
+              },
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "file",
+                  "file": {
+                    "src": "aEKqpnIMk/1_extract_your_first_data.pdf"
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/extract/{{DOCUMENT_TYPE}}?environment=production",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "extract",
+                    "{{DOCUMENT_TYPE}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "environment",
+                      "value": "production"
+                    }
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Extract doc at Sensible URL",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/generate_upload_url/{{DOCUMENT_TYPE}}?environment=production",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "generate_upload_url",
+                    "{{DOCUMENT_TYPE}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "environment",
+                      "value": "production"
+                    }
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Extract doc at your URL",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\"document_url\":\"{{DOCUMENT_URL}}\"}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/extract_from_url/{{DOCUMENT_TYPE}}?environment=production",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "extract_from_url",
+                    "{{DOCUMENT_TYPE}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "environment",
+                      "value": "production"
+                    }
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Portfolio",
+          "item": [
+            {
+              "name": "Extract portfolio at Sensible URL",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\"types\": [\r\n          \"{{DOCUMENT_TYPE}}\"\r\n     ]}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/generate_upload_url?environment=production",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "generate_upload_url"
+                  ],
+                  "query": [
+                    {
+                      "key": "environment",
+                      "value": "production"
+                    }
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Extract portfolio at your URL",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\"document_url\":\"{{PORTFOLIO_URL}}\",\r\n    \"types\": [\r\n          \"{{DOCUMENT_TYPE}}\"\r\n     ]\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/extract_from_url?environment=production",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "extract_from_url"
+                  ],
+                  "query": [
+                    {
+                      "key": "environment",
+                      "value": "production"
+                    }
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Retrieve extraction",
+          "item": [
+            {
+              "name": "Retrieve extraction",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/documents/{{EXTRACTION_ID}}",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "documents",
+                    "{{EXTRACTION_ID}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "List extractions",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/extractions",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "extractions"
+                  ],
+                  "query": [
+                    {
+                      "key": "start_date",
+                      "value": "2020-10-10T00:00:00.000Z",
+                      "disabled": true
+                    },
+                    {
+                      "key": "end_date",
+                      "value": "2023-12-30T00:00:00.000Z",
+                      "disabled": true
+                    },
+                    {
+                      "key": "configuration_ids",
+                      "value": null,
+                      "disabled": true
+                    },
+                    {
+                      "key": "document_type_ids",
+                      "value": null,
+                      "disabled": true
+                    },
+                    {
+                      "key": "environments",
+                      "value": null,
+                      "disabled": true
+                    },
+                    {
+                      "key": "statuses",
+                      "value": null,
+                      "disabled": true
+                    },
+                    {
+                      "key": "continuation_token",
+                      "value": "eyJpZCI6IjRiNTg1Mjc4LWUwOWMtNGJiOS04ODJiLThmYjFhZTA3ZGU3ZiIsInVzZXIiOiJjMDI0Y2QxYy01ZMMzLTRhODItYjJlYS0yYzgwN2U0NDk4OGIiLCJjcmVhdGVkIjoiMjAyNC0wNS0wMVQyMjo11Do1NS43MzMaIn1",
+                      "disabled": true
+                    }
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Get extraction statistics",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/extractions/statistics?start_date=2020-10-10T00:00:00.000Z&end_date=2023-12-30T00:00:00.000Z",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "extractions",
+                    "statistics"
+                  ],
+                  "query": [
+                    {
+                      "key": "start_date",
+                      "value": "2020-10-10T00:00:00.000Z"
+                    },
+                    {
+                      "key": "end_date",
+                      "value": "2023-12-30T00:00:00.000Z"
+                    }
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Get Excel from PDFs",
+          "item": [
+            {
+              "name": "Get Excel extraction",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/generate_excel/{{EXTRACTION_ID}}",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "generate_excel",
+                    "{{EXTRACTION_ID}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Get CSV extraction",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/generate_csv/{{EXTRACTION_ID}}",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "generate_csv",
+                    "{{EXTRACTION_ID}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Review extractions",
+          "item": [
+            {
+              "name": "Get auth token for review",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n    \"grants\": [\r\n        {\r\n            \"route\": \"/documents/{id}\",\r\n            \"method\": \"GET\",\r\n            \"path\": {\r\n                \"id\": {{EXTRACTION_ID}}\r\n            }\r\n        },\r\n        {\r\n            \"route\": \"/extractions/{id}\",\r\n            \"method\": \"PUT\",\r\n            \"path\": {\r\n                \"id\": {{EXTRACTION_ID}}\r\n            }\r\n        }\r\n    ],\r\n    \"expires\": \"2025-01-15T22:14:35.720Z\"\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/account/auth_tokens",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "account",
+                    "auth_tokens"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "CONFIGURATION",
+      "item": [
+        {
+          "name": "Document type",
+          "item": [
+            {
+              "name": "List document types",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Get document type",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types/{{DOC_TYPE_ID}}",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types",
+                    "{{DOC_TYPE_ID}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Create document type",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n     \"schema\": {\r\n          \"ocr_engine\": \"microsoft\",\r\n          \"fingerprint_mode\": \"fallback_to_all\"\r\n     },\r\n     \"name\": \"{{DOCUMENT_TYPE}}\"\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Update document type",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n     \"schema\": {\r\n          \"ocr_engine\": \"google\"\r\n     }\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types/{{DOC_TYPE_ID}}",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types",
+                    "{{DOC_TYPE_ID}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Delete document type",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "DELETE",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types/{{DOC_TYPE_ID}}",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types",
+                    "{{DOC_TYPE_ID}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Configuration",
+          "item": [
+            {
+              "name": "List configurations",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types/{{DOC_TYPE_ID}}/configurations",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types",
+                    "{{DOC_TYPE_ID}}",
+                    "configurations"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Get configuration",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types/{{DOC_TYPE_ID}}/configurations/{{CONFIG_NAME}}",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types",
+                    "{{DOC_TYPE_ID}}",
+                    "configurations",
+                    "{{CONFIG_NAME}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Create configuration",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n     \"name\": \"{{CONFIG_NAME}}\",\r\n     \"publish_as\": \"development\",\r\n     \"configuration\": \"{ \\t\\\"fingerprint\\\": { \\t\\t\\\"tests\\\": [ \\t\\t\\t\\\"anyco\\\", \\t\\t\\t\\\"quoted coverage changes\\\" \\t\\t] \\t}, \\t\\\"preprocessors\\\": [{ \\t\\t\\\"type\\\": \\\"pageRange\\\", \\t\\t\\\"startPage\\\": 0, \\t\\t\\\"endPage\\\": 2 \\t}], \\t\\\"fields\\\": [{ \\t\\t\\\"id\\\": \\\"_driver_name_raw\\\", \\t\\t\\\"anchor\\\": \\\"name of driver\\\", \\t\\t\\\"method\\\": { \\t\\t\\t\\\"id\\\": \\\"label\\\", \\t\\t\\t\\\"position\\\": \\\"below\\\" \\t\\t} \\t}], \\t\\\"computed_fields\\\": [{ \\t\\t\\t\\\"id\\\": \\\"driver_name_last\\\", \\t\\t\\t\\\"method\\\": { \\t\\t\\t\\t\\\"id\\\": \\\"split\\\", \\t\\t\\t\\t\\\"source_id\\\": \\\"_driver_name_raw\\\", \\t\\t\\t\\t\\\"separator\\\": \\\", \\\", \\t\\t\\t\\t\\\"index\\\": 1 \\t\\t\\t} \\t\\t}  \\t] }\\n\"\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types/{{DOC_TYPE_ID}}/configurations",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types",
+                    "{{DOC_TYPE_ID}}",
+                    "configurations"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Update configuration",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\r\n     \"name\": \"{{CONFIG_NAME}}\",\r\n     \"current_draft\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\",\r\n     \"configuration\": \"{ \\t\\\"fields\\\": [{ \\t\\t\\\"id\\\": \\\"_driver_name_raw\\\", \\t\\t\\\"anchor\\\": \\\"name of driver\\\", \\t\\t\\\"method\\\": { \\t\\t\\t\\\"id\\\": \\\"label\\\", \\t\\t\\t\\\"position\\\": \\\"below\\\" \\t\\t} \\t}], \\t\\\"computed_fields\\\": [{ \\t\\t\\t\\\"id\\\": \\\"driver_name_last\\\", \\t\\t\\t\\\"method\\\": { \\t\\t\\t\\t\\\"id\\\": \\\"split\\\", \\t\\t\\t\\t\\\"source_id\\\": \\\"_driver_name_raw\\\", \\t\\t\\t\\t\\\"separator\\\": \\\", \\\", \\t\\t\\t\\t\\\"index\\\": 1 \\t\\t\\t} \\t\\t}  \\t] }\\n\"\r\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types/{{DOC_TYPE_ID}}/configurations",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types",
+                    "{{DOC_TYPE_ID}}",
+                    "configurations"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Delete configuration",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{API_KEY}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "DELETE",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{BASE_URL}}/document_types/{{DOC_TYPE_ID}}/configurations/{{CONFIG_NAME}}",
+                  "host": [
+                    "{{BASE_URL}}"
+                  ],
+                  "path": [
+                    "document_types",
+                    "{{DOC_TYPE_ID}}",
+                    "configurations",
+                    "{{CONFIG_NAME}}"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "See API reference for more config endpoints",
+          "item": []
+        }
+      ]
+    },
+    {
+      "name": "CLASSIFICATION",
+      "item": [
+        {
+          "name": "Classify document by type",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "image/jpeg"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "file",
+              "file": {}
+            },
+            "url": {
+              "raw": "{{baseUrl}}/classify/async?document_types=doc_type1, doc_type2",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "classify",
+                "async"
+              ],
+              "query": [
+                {
+                  "key": "document_types",
+                  "value": "doc_type1, doc_type2"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "The document type and reference documents in the Sensible account that are most similar to this document.\n",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"document_type\": {\n    \"id\": \"<string>\",\n    \"name\": \"<string>\",\n    \"score\": \"<number>\"\n  },\n  \"reference_documents\": [\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\"\n    }\n  ],\n  \"classification_summary\": [\n    {\n      \"id\": \"<string>\",\n      \"score\": \"<number>\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"score\": \"<number>\"\n    }\n  ]\n}"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Bad Request",
+              "code": 400,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Unsupported Media Type",
+              "code": 415,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            }
+          ]
+        },
+        {
+          "name": "Classify document by type (sync)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/pdf"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "file",
+              "file": {}
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/classify?document_types=doc_type1, doc_type2",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "classify"
+              ],
+              "query": [
+                {
+                  "key": "document_types",
+                  "value": "doc_type1, doc_type2"
+                }
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "The document type and reference documents in the Sensible account that are most similar to this document.\n",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "json",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n  \"document_type\": {\n    \"id\": \"<string>\",\n    \"name\": \"<string>\",\n    \"score\": \"<number>\"\n  },\n  \"reference_documents\": [\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"name\": \"<string>\"\n    }\n  ],\n  \"classification_summary\": [\n    {\n      \"id\": \"<string>\",\n      \"score\": \"<number>\"\n    },\n    {\n      \"id\": \"<string>\",\n      \"score\": \"<number>\"\n    }\n  ]\n}"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Bad Request",
+              "code": 400,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Unauthorized",
+              "code": 401,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Unsupported Media Type",
+              "code": 415,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Too Many Requests",
+              "code": 429,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            },
+            {
+              "name": "Untitled Response",
+              "originalRequest": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "image/jpeg"
+                  },
+                  {
+                    "description": "Added as a part of security scheme: bearer",
+                    "key": "Authorization",
+                    "value": "Bearer <token>"
+                  }
+                ],
+                "body": {
+                  "mode": "file",
+                  "file": {}
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/classify",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "classify"
+                  ]
+                }
+              },
+              "status": "Internal Server Error",
+              "code": 500,
+              "_postman_previewlanguage": "text",
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "cookie": [],
+              "body": "<string>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "EMAIL PROCESSORS",
+      "item": [
+        {
+          "name": "List email processors",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{API_KEY}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/processors/email",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "processors",
+                "email"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get email processor",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{API_KEY}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{BASE_URL}}/processors/email/{{PROCESSOR_NAME}}",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "processors",
+                "email",
+                "{{PROCESSOR_NAME}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create or update email processor",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{API_KEY}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"webhooks\": [\r\n    {\r\n      \"url\": \"https://your-webhook-url.example.com\"\r\n    }\r\n  ],\r\n  \"bodySpec\": {\r\n    \"kind\": \"doctype\",\r\n    \"docTypeId\": \"{{DOC_TYPE_ID}}\"\r\n  },\r\n  \"attachmentSpecs\": [\r\n    {\r\n      \"kind\": \"doctype\",\r\n      \"docTypeId\": \"{{DOC_TYPE_ID}}\"\r\n    }\r\n  ]\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/processors/email/{{PROCESSOR_NAME}}",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "processors",
+                "email",
+                "{{PROCESSOR_NAME}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete email processor",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{API_KEY}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "DELETE",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{BASE_URL}}/processors/email/{{PROCESSOR_NAME}}",
+              "host": [
+                "{{BASE_URL}}"
+              ],
+              "path": [
+                "processors",
+                "email",
+                "{{PROCESSOR_NAME}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{API_KEY}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "BASE_URL",
+      "value": "https://api.sensible.so/v0",
+      "type": "string"
+    },
+    {
+      "key": "API_KEY",
+      "value": "FILL_IN_YOUR_API_KEY",
+      "type": "string"
+    },
+    {
+      "key": "DOCUMENT_TYPE",
+      "value": "senseml_basics",
+      "type": "string"
+    },
+    {
+      "key": "PORTFOLIO_URL",
+      "value": "https://github.com/sensible-hq/sensible-docs/raw/main/readme-sync/assets/v0/pdfs/portfolio.pdf",
+      "type": "string"
+    },
+    {
+      "key": "DOCUMENT_URL",
+      "value": "https://github.com/sensible-hq/sensible-docs/raw/main/readme-sync/assets/v0/pdfs/1_extract_your_first_data.pdf",
+      "type": "string"
+    },
+    {
+      "key": "EXTRACTION_ID",
+      "value": "\"EXTRACTION_ID\"",
+      "type": "string"
+    },
+    {
+      "key": "DOC_TYPE_ID",
+      "value": "RETURNED_BY_GET_DOC_TYPES_ENDPOINT",
+      "type": "string"
+    },
+    {
+      "key": "CONFIG_NAME",
+      "value": "1_extract_your_first_data",
+      "type": "string"
+    },
+    {
+      "key": "PROCESSOR_NAME",
+      "value": "my_processor",
+      "type": "string"
+    }
+  ]
+}

--- a/reference/openapi_email.json
+++ b/reference/openapi_email.json
@@ -1,0 +1,522 @@
+{
+  "openapi": "3.0.3",
+  "servers": [
+    {
+      "url": "https://api.sensible.so/v0",
+      "description": "Production server (uses live data)"
+    }
+  ],
+  "info": {
+    "title": "Email processors",
+    "version": "0.0.1",
+    "description": "Sensible API for managing email processors.",
+    "license": {
+      "name": "Sensible API",
+      "url": "https://www.TBD.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Email processor",
+      "description": "Create and manage email processors"
+    }
+  ],
+  "paths": {
+    "/processors/email": {
+      "get": {
+        "operationId": "list-email-processors",
+        "summary": "List email processors",
+        "description": "Lists all active email processors for this account.",
+        "tags": [
+          "Email processor"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of active email processors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmailProcessorOutput"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/processors/email/{name}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/processorName"
+        }
+      ],
+      "get": {
+        "operationId": "get-email-processor",
+        "summary": "Get email processor",
+        "description": "Retrieves an email processor by name.",
+        "tags": [
+          "Email processor"
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested email processor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailProcessorOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      },
+      "put": {
+        "operationId": "upsert-email-processor",
+        "summary": "Create or update email processor",
+        "description": "Creates an email processor with the given name, or replaces it if one already exists. You define which document types Sensible extracts from the email body and attachments, and which webhooks receive the extraction output.",
+        "tags": [
+          "Email processor"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmailProcessorInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The created or updated email processor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailProcessorOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "delete-email-processor",
+        "summary": "Delete email processor",
+        "description": "Deletes an email processor. If no processor with the given name exists, Sensible takes no action.",
+        "tags": [
+          "Email processor"
+        ],
+        "responses": {
+          "200": {
+            "description": "Processor deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "EmailProcessorInput": {
+        "description": "Configuration for an email processor. You must specify at least one of `bodySpec` or `attachmentSpecs`.",
+        "oneOf": [
+          {
+            "description": "Processor that extracts from the email body. You may also specify attachment specs.",
+            "type": "object",
+            "required": [
+              "webhooks",
+              "bodySpec"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "webhooks": {
+                "$ref": "#/components/schemas/WebhookList"
+              },
+              "bodySpec": {
+                "$ref": "#/components/schemas/SingleDocTypeSpec"
+              },
+              "attachmentSpecs": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Specs for extracting from email attachments. Each spec defines a document type or classification strategy for one attachment.",
+                "items": {
+                  "$ref": "#/components/schemas/AttachmentSpec"
+                }
+              }
+            }
+          },
+          {
+            "description": "Processor that extracts from attachments only. You may also specify a body spec.",
+            "type": "object",
+            "required": [
+              "webhooks",
+              "attachmentSpecs"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "webhooks": {
+                "$ref": "#/components/schemas/WebhookList"
+              },
+              "bodySpec": {
+                "$ref": "#/components/schemas/SingleDocTypeSpec"
+              },
+              "attachmentSpecs": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Specs for extracting from email attachments. Each spec defines a document type or classification strategy for one attachment.",
+                "items": {
+                  "$ref": "#/components/schemas/AttachmentSpec"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "EmailProcessorOutput": {
+        "description": "An email processor returned by the API.",
+        "type": "object",
+        "required": [
+          "name",
+          "created",
+          "webhooks"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The processor's unique name within the account."
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The ISO 8601 timestamp when Sensible created the processor."
+          },
+          "webhooks": {
+            "$ref": "#/components/schemas/WebhookList"
+          },
+          "bodySpec": {
+            "$ref": "#/components/schemas/SingleDocTypeSpec"
+          },
+          "attachmentSpecs": {
+            "type": "array",
+            "description": "The extraction specs configured for email attachments.",
+            "items": {
+              "$ref": "#/components/schemas/AttachmentSpec"
+            }
+          }
+        }
+      },
+      "WebhookList": {
+        "type": "array",
+        "minItems": 1,
+        "description": "Webhooks that receive extraction output. The first element is the production webhook. Additional elements are environment-scoped webhooks that override the production webhook for a specific environment.",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/Webhook"
+            },
+            {
+              "$ref": "#/components/schemas/EnvironmentWebhook"
+            }
+          ]
+        }
+      },
+      "Webhook": {
+        "description": "The production webhook. Sensible sends extraction output to this URL unless an environment-scoped webhook matches the extraction environment.",
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL Sensible posts extraction output to."
+          }
+        }
+      },
+      "EnvironmentWebhook": {
+        "description": "An environment-scoped webhook. Sensible sends extraction output to this URL when the extraction environment matches `environment`.",
+        "type": "object",
+        "required": [
+          "url",
+          "environment"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL Sensible posts extraction output to."
+          },
+          "environment": {
+            "type": "string",
+            "description": "The environment this webhook applies to, for example `\"development\"` or `\"staging\"`."
+          }
+        }
+      },
+      "AttachmentSpec": {
+        "description": "Defines how Sensible handles one email attachment. Use `kind` to specify whether Sensible extracts against a single document type, classifies across multiple types, or treats the attachment as a portfolio.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SingleDocTypeSpec"
+          },
+          {
+            "$ref": "#/components/schemas/ClassificationSpec"
+          },
+          {
+            "$ref": "#/components/schemas/PortfolioSpec"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "doctype": "#/components/schemas/SingleDocTypeSpec",
+            "classification": "#/components/schemas/ClassificationSpec",
+            "portfolio": "#/components/schemas/PortfolioSpec"
+          }
+        }
+      },
+      "SingleDocTypeSpec": {
+        "description": "Extracts against a single document type.",
+        "type": "object",
+        "required": [
+          "kind",
+          "docTypeId"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "doctype"
+            ]
+          },
+          "docTypeId": {
+            "type": "string",
+            "description": "The ID of the document type Sensible extracts against."
+          }
+        }
+      },
+      "ClassificationSpec": {
+        "description": "Classifies the attachment across multiple document types before extracting.",
+        "type": "object",
+        "required": [
+          "kind",
+          "docTypeIds"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "classification"
+            ]
+          },
+          "docTypeIds": {
+            "type": "array",
+            "minItems": 1,
+            "description": "The IDs of the document types Sensible classifies the attachment against.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PortfolioSpec": {
+        "description": "Treats the attachment as a portfolio — a single file containing multiple documents — and extracts each sub-document separately.",
+        "type": "object",
+        "required": [
+          "kind",
+          "docTypeIds"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "portfolio"
+            ]
+          },
+          "docTypeIds": {
+            "type": "array",
+            "minItems": 1,
+            "description": "The IDs of the document types Sensible extracts from each sub-document in the portfolio.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ocrEngine": {
+            "type": "string",
+            "enum": [
+              "tika",
+              "ocrmypdf",
+              "amazon-textract",
+              "microsoft",
+              "microsoft2",
+              "microsoft3",
+              "microsoft4",
+              "microsoft5",
+              "pdf"
+            ],
+            "description": "The OCR engine Sensible uses to process the portfolio. If unspecified, Sensible uses the document type's configured OCR engine."
+          },
+          "segmentDocumentsWith": {
+            "type": "string",
+            "description": "The segmentation method Sensible uses to split the portfolio into sub-documents. For more information, see [portfolio](doc:portfolio)."
+          },
+          "ocrEveryPage": {
+            "type": "boolean",
+            "description": "Specifies whether Sensible runs OCR on every page of the portfolio, including pages that contain native text. Defaults to false."
+          }
+        }
+      }
+    },
+    "parameters": {
+      "processorName": {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "description": "The processor name. Must consist of lowercase letters, numbers, and underscores.",
+        "schema": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]+$"
+        }
+      }
+    },
+    "responses": {
+      "400": {
+        "description": "Bad Request",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "title": "Bad Request",
+              "type": "string",
+              "example": "Invalid processor name. Must consist of lowercase letters, numbers, and underscores."
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "Not authorized",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "title": "Unauthorized",
+              "type": "string",
+              "example": "Unauthorized"
+            }
+          }
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "title": "Forbidden",
+              "type": "string",
+              "example": "This endpoint requires at least one active account alias."
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "Not Found",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "title": "Not Found",
+              "type": "string"
+            }
+          }
+        }
+      },
+      "500": {
+        "description": "Internal Server Error",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "title": "Sensible encountered an unknown error",
+              "type": "string",
+              "example": "Sensible encountered an unknown error"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Sensible uses API keys to authenticate requests. Keep your API keys secure and do not share them publicly accessible areas such as GitHub, client-side code, etc. Authentication to the API is performed via Bearer Authentication. Provide your API key as the bearer auth value."
+      }
+    }
+  }
+}

--- a/reference/openapi_email.json
+++ b/reference/openapi_email.json
@@ -156,14 +156,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Processor deleted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
+            "description": "Processor deleted"
           },
           "400": {
             "$ref": "#/components/responses/400"
@@ -185,58 +178,27 @@
     "schemas": {
       "EmailProcessorInput": {
         "description": "Configuration for an email processor. You must specify at least one of `bodySpec` or `attachmentSpecs`.",
-        "oneOf": [
-          {
-            "description": "Processor that extracts from the email body. You may also specify attachment specs.",
-            "type": "object",
-            "required": [
-              "webhooks",
-              "bodySpec"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "webhooks": {
-                "$ref": "#/components/schemas/WebhookList"
-              },
-              "bodySpec": {
-                "$ref": "#/components/schemas/SingleDocTypeSpec"
-              },
-              "attachmentSpecs": {
-                "type": "array",
-                "minItems": 1,
-                "description": "Specs for extracting from email attachments. Each spec defines a document type or classification strategy for one attachment.",
-                "items": {
-                  "$ref": "#/components/schemas/AttachmentSpec"
-                }
-              }
-            }
+        "type": "object",
+        "required": [
+          "webhooks"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "webhooks": {
+            "$ref": "#/components/schemas/WebhookList"
           },
-          {
-            "description": "Processor that extracts from attachments only. You may also specify a body spec.",
-            "type": "object",
-            "required": [
-              "webhooks",
-              "attachmentSpecs"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "webhooks": {
-                "$ref": "#/components/schemas/WebhookList"
-              },
-              "bodySpec": {
-                "$ref": "#/components/schemas/SingleDocTypeSpec"
-              },
-              "attachmentSpecs": {
-                "type": "array",
-                "minItems": 1,
-                "description": "Specs for extracting from email attachments. Each spec defines a document type or classification strategy for one attachment.",
-                "items": {
-                  "$ref": "#/components/schemas/AttachmentSpec"
-                }
-              }
+          "bodySpec": {
+            "$ref": "#/components/schemas/SingleDocTypeSpec"
+          },
+          "attachmentSpecs": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Specs for extracting from email attachments. Each spec defines a document type or classification strategy for one attachment.",
+            "items": {
+              "$ref": "#/components/schemas/AttachmentSpec"
             }
           }
-        ]
+        }
       },
       "EmailProcessorOutput": {
         "description": "An email processor returned by the API.",
@@ -274,7 +236,7 @@
       "WebhookList": {
         "type": "array",
         "minItems": 1,
-        "description": "Webhooks that receive extraction output. The first element is the production webhook. Additional elements are environment-scoped webhooks that override the production webhook for a specific environment.",
+        "description": "Webhooks that receive extraction output. The first element must be a production `Webhook` (a `url` with no `environment` field). Additional elements must be `EnvironmentWebhook` objects that override the production webhook for a specific environment. The API rejects arrays whose first element is an `EnvironmentWebhook`. Note: OpenAPI 3.0.3 cannot enforce positional constraints in arrays, so schema validators will not catch this ordering violation.",
         "items": {
           "oneOf": [
             {
@@ -415,13 +377,10 @@
           "ocrEngine": {
             "type": "string",
             "enum": [
-              "tika",
-              "ocrmypdf",
-              "amazon-textract",
+              "amazon",
+              "google",
+              "lazarus",
               "microsoft",
-              "microsoft2",
-              "microsoft3",
-              "microsoft4",
               "microsoft5",
               "pdf"
             ],
@@ -429,6 +388,10 @@
           },
           "segmentDocumentsWith": {
             "type": "string",
+            "enum": [
+              "llm",
+              "fingerprints"
+            ],
             "description": "The segmentation method Sensible uses to split the portfolio into sub-documents. For more information, see [portfolio](doc:portfolio)."
           },
           "ocrEveryPage": {


### PR DESCRIPTION
## Summary

- Adds `reference/openapi_email.json` — OpenAPI 3.0.3 spec for the email processors CRUD API
- Covers 4 endpoints: list, get, upsert, and delete (`/processors/email` and `/processors/email/{name}`)
- Full request/response schemas including discriminated union attachment specs (`doctype`, `classification`, `portfolio`)
- Also adds `.claude/skills/sensible-api-spec/` — skill for generating API reference specs from backend PRs in future

Based on sensible-hq/sensible#3190, #3237, #3242, #3287.

## Test plan

- [ ] Upload `openapi_email.json` to readme.io and verify all 4 endpoints render correctly
- [ ] Check request body schema for `upsert-email-processor` shows the discriminated union attachment specs
- [ ] Verify 403 response description is accurate for accounts without active aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)