### PR TITLE
docs: add Random JsonLogic operator

### DIFF
--- a/docs/Senseml reference/concepts/jsonlogic.md
+++ b/docs/Senseml reference/concepts/jsonlogic.md
@@ -54,6 +54,7 @@ Sensible extends JsonLogic with custom operations. The following table lists the
 | [Object](doc:jsonlogic#object)               | ✅                                       | ✅                                                    | ✅                                  |
 | [Omit fields](doc:jsonlogic#omit-fields)     | ✅                                       | ✅                                                    | ✅                                  |
 | [Pick Fields](doc:jsonlogic#pick-fields)     | ✅                                       | ✅                                                    | ✅                                  |
+| [Random](doc:jsonlogic#random)               | ✅                                       | ✅                                                    | ✅                                  |
 | [Replace](doc:jsonlogic#replace)             | ✅                                       | ✅                                                    | ✅                                  |
 | [Round](doc:jsonlogic#round)                 | ✅                                       | ✅                                                    | ✅                                  |
 | [Slice](doc:jsonlogic#slice)                 | ✅                                       | ✅                                                    | ✅                                  |
@@ -1069,6 +1070,47 @@ the rule outputs:
 #### Example 2
 
 For a complete example, see [Custom computation group](doc:custom-computation-group).
+
+## Random
+
+Returns a random float in the range [0, 1). Takes no arguments. Each call returns a new value, so results are non-deterministic across extractions.
+
+```json
+{ "random": [] }
+```
+
+### Example
+
+The following example shows using the Random operator to flag roughly half of extractions for quality review.
+
+```json
+{
+  "fields": [],
+  "computed_fields": [
+    {
+      "id": "flag_for_review",
+      "method": {
+        "id": "customComputation",
+        "jsonLogic": {
+          /* true ~50% of the time */
+          ">": [{ "random": [] }, 0.5]
+        }
+      }
+    }
+  ]
+}
+```
+
+This returns:
+
+```json
+{
+  "flag_for_review": {
+    "value": true,
+    "type": "boolean"
+  }
+}
+```
 
 ## Replace
 

--- a/docs/Senseml reference/concepts/jsonlogic.md
+++ b/docs/Senseml reference/concepts/jsonlogic.md
@@ -1081,27 +1081,27 @@ Returns a random float in the range [0, 1). Takes no arguments. Each call return
 
 ### Example
 
-The following example shows using the Random operator to flag roughly half of extractions for quality review.
+The following example shows using the Random operator to flag roughly half of extractions for [human review](doc:human-review-implementation).
 
 ```json
 {
-  "fields": [],
-  "computed_fields": [
+  "fields": [
     {
-      "id": "flag_for_review",
+      "id": "flag_for_review", /* create a JSON validation to flag extraction with `NEEDS_REVIEW` status when this field is `true`  */
       "method": {
         "id": "customComputation",
         "jsonLogic": {
-          /* true ~50% of the time */
+          /* true about 50% of the time */
           ">": [{ "random": [] }, 0.5]
         }
       }
     }
-  ]
+  ],
+
 }
 ```
 
-This returns:
+This returns `true` or `false`, each about 50% of the time. For example:
 
 ```json
 {

--- a/docs/monitor and qa/human-review-implementation.md
+++ b/docs/monitor and qa/human-review-implementation.md
@@ -16,7 +16,7 @@ The following diagram shows how to integrate human-in-the-loop review into your 
 
 ![Click to enlarge](https://raw.githubusercontent.com/sensible-hq/sensible-docs/v0/assets/images/final/human_review_5.png)
 
-1. **Enable review and configure review triggers**: Enable and configure extraction quality validation for a document type, for example, tax documents or pay stubs. Any extraction in the document type that doesn’t meet your quality validations triggers a human review.
+1. **Enable review and configure review triggers**: Enable and configure extraction quality validation for a document type, for example, tax documents or pay stubs. Any extraction in the document type that doesn’t meet your quality [validations](doc:validate-extractions) triggers a human review.
 2. **Specify a webhook for each document extraction:** When extracting data from a document using Sensible’s API or SDK, specify a webhook destination URL that receives updates to the extraction’s review status. 
 3. **Notify a reviewer**: When the webhook indicates that a completed extraction needs review and correction, notify a reviewer and send them a link to the review interface that they can following without having to log in to Sensible.
 4. **Ingest corrected extractions**: When the webhook indicates that a reviewer approved an extraction, ingest the document data into your system.


### PR DESCRIPTION
## Summary

- Adds `Random` to the Sensible-specific operations table in `jsonlogic.md` (alphabetically between Pick Fields and Replace)
- Adds `## Random` section with syntax, description, and a practical example (random sampling flag)

Based on [sensible-hq/sensible#3296](https://github.com/sensible-hq/sensible/pull/3296).

## Test plan

- [ ] Verify `Random` row appears correctly in the operations table
- [ ] Verify the `## Random` section renders correctly with the code example
- [ ] Verify the example JSON comment (`/* true ~50% of the time */`) renders as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)