### PR TITLE
feat(vale): add Sensible-specific style rules and disable Google.Colons

### DIFF
--- a/.github/styles/Sensible/AgainstPhrasing.yml
+++ b/.github/styles/Sensible/AgainstPhrasing.yml
@@ -1,0 +1,5 @@
+extends: existence
+message: "Avoid 'against' for extraction or classification. Use 'using' instead."
+level: warning
+tokens:
+  - '(?:extract(?:s|ed|ing)?|classif(?:ies|y|ied|ication)?)(?:\s+\S+)+\s+against'

--- a/.github/styles/Sensible/Terminology.yml
+++ b/.github/styles/Sensible/Terminology.yml
@@ -1,0 +1,8 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+level: warning
+action:
+  name: replace
+swap:
+  'the editor': the Sensible app
+  'the UI': the Sensible app

--- a/.vale.ini
+++ b/.vale.ini
@@ -8,6 +8,7 @@ Vocab = Sensible
 [*.md]
 BasedOnStyles = Vale, Google, Sensible
 Google.WordList = NO
+Google.Colons = NO
 
 [.claude/**]
 BasedOnStyles =


### PR DESCRIPTION
## Summary

- Disables `Google.Colons` to stop Vale flagging capitalized words after colons (e.g. `Note: Please be aware...`)
- Adds `AgainstPhrasing` rule: flags `classifies/extracts X against` and suggests `using` instead
- Adds `Terminology` rule: flags `the editor` and `the UI` and suggests `the Sensible app`

## Test plan

- [ ] Run Vale on `docs/integrations/getting-started-email.md` — should see `AgainstPhrasing` warnings on lines 180–181
- [ ] Run Vale on `docs/document extraction/getting-started.md` — should see `Terminology` warnings on lines 76 and 525
- [ ] Confirm `Note: Please...` patterns no longer trigger a Vale warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)